### PR TITLE
Add selector for `compile_commands.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The extension provides the following commands:
 | `CodeChecker: Analyze selected files...` | Analyzes the files selected by the user, using CodeChecker. Accepts multiple files as input. |
 | `CodeChecker: Analyze entire project` | Analyzes the entire project using CodeChecker. Can also be called by clicking on the `Re-analyze entire project` button in CodeChecker's side panel.<br> *Warning:* A full analysis can take minutes, or even hours on larger projects. |
 | `CodeChecker: Stop analysis` | Stops the currently running analysis. Partial results are saved and updated. |
+| `CodeChecker: Show database setup dialog` | Shows the dialog to select the path to an existing compilation database, or to create a new one. |
 | `CodeChecker: Next reproduction step`, <br> `CodeChecker: Previous reproduction step` | Moves between a displayed reproduction path's steps. You can also navigate directly to a report's step via CodeChecker's side panel. <br> Default keybinds: `Ctrl-F7`, `Ctrl-Shift-F7` respectively. |
 | `CodeChecker: Show full command line` | Shows the full CodeChecker command line used to analyze files. <br> Useful if you want to review the analyzer's options before running, or if you want to run the analysis manually. |
 | `CodeChecker: Show Output` | Focuses CodeChecker's output in the editor. The plugin's logs, as well as the output of previous CodeChecker runs are displayed here. |
@@ -56,6 +57,8 @@ Since CodeChecker-related paths vary greatly between systems, the following sett
 | Name | Description |
 | --- | --- |
 | CodeChecker > Backend > Output folder <br> (default: `${workspaceFolder}/.codechecker`) | The output folder where the CodeChecker analysis files are stored. |
+| CodeChecker > Backend > Database path <br> (default: *(empty)*) | Path to a custom compilation database, in case of a custom build system. The database setup dialog sets the path for the current workspace only. |
+| CodeChecker > Editor > Show database dialog <br> (default: `on`) | Controls the dialog when opening a workspace without a compilation database. |
 | CodeChecker > Executor > Executable path <br> (default: `CodeChecker`) |  Path to the CodeChecker executable (can be an executable in the `PATH` environment variable). |
 | CodeChecker > Executor > Thread count <br> (default: *(empty)*) | CodeChecker's thread count - leave empty to use all threads. |
 | CodeChecker > Executor > Arguments <br> (default: *(empty)*) | Additional arguments to CodeChecker. For supported arguments, run `CodeChecker analyze --help`. <br> *Note:* The resulting command-line can be previewed with the command `CodeChecker: Show full command line`. |

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
         "title": "CodeChecker: Previous reproduction step"
       },
       {
+        "command": "codechecker.editor.showSetupDialog",
+        "title": "CodeChecker: Show database setup dialog"
+      },
+      {
         "command": "codechecker.executor.analyzeCurrentFile",
         "title": "CodeChecker: Analyze current file"
       },
@@ -71,6 +75,19 @@
           "type": "string",
           "description": "Output folder for CodeChecker's analysis files",
           "default": "${workspaceFolder}/.codechecker"
+        },
+        "codechecker.backend.databasePath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Path to a custom compilation database, in case of a custom build system",
+          "default": null
+        },
+        "codechecker.editor.showDatabaseDialog": {
+          "type": "boolean",
+          "description": "Show a dialog if the compilation database is not found",
+          "default": true
         },
         "codechecker.executor.executablePath": {
           "type": "string",

--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -1,7 +1,7 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { Event, EventEmitter, ExtensionContext, Uri, window, workspace } from 'vscode';
+import { Disposable, Event, EventEmitter, ExtensionContext, FileSystemWatcher, Uri, window, workspace } from 'vscode';
 
 export enum ProcessStatus {
     notRunning,
@@ -11,7 +11,7 @@ export enum ProcessStatus {
     errored,
 }
 
-export class ExecutorProcess {
+export class ExecutorProcess implements Disposable {
     activeProcess?: child_process.ChildProcess;
 
     /** Every line should have a newline at the end */
@@ -44,7 +44,66 @@ export class ExecutorProcess {
         return this._processStatusChange.event;
     }
 
-    constructor(_ctx: ExtensionContext) {
+    private _databaseLocationChanged: EventEmitter<void> = new EventEmitter();
+    public get databaseLocationChanged(): Event<void> {
+        return this._databaseLocationChanged.event;
+    }
+
+    private databaseWatches: FileSystemWatcher[] = [];
+    private databaseEvents: Disposable[] = [];
+    private databasePaths: (string | undefined)[] = [];
+
+    /** Automatically adds itself to ctx.subscriptions. */
+    constructor(ctx: ExtensionContext) {
+        ctx.subscriptions.push(this);
+        workspace.onDidChangeConfiguration(this.updateDatabasePaths, this, ctx.subscriptions);
+
+        this.updateDatabasePaths();
+    }
+
+    dispose() {
+        this.databaseEvents.forEach(watch => watch.dispose());
+        this.databaseWatches.forEach(watch => watch.dispose());
+    }
+
+    updateDatabasePaths() {
+        if (!workspace.workspaceFolders?.length) {
+            return;
+        }
+
+        const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
+
+        const getConfigAndReplaceVariables = (category: string, name: string): string | undefined => {
+            const configValue = workspace.getConfiguration(category).get<string>(name);
+            return configValue
+                ?.replace(/\${workspaceRoot}/g, workspaceFolder)
+                .replace(/\${workspaceFolder}/g, workspaceFolder)
+                .replace(/\${cwd}/g, process.cwd())
+                .replace(/\${env\.([^}]+)}/g, (sub: string, envName: string) => process.env[envName] ?? '');
+        };
+
+        const ccFolder = getConfigAndReplaceVariables('codechecker.backend', 'outputFolder')
+            ?? path.join(workspaceFolder, '.codechecker');
+
+        this.databasePaths = [
+            getConfigAndReplaceVariables('codechecker.backend', 'databasePath'),
+            path.join(ccFolder, 'compile_commands.json'),
+            path.join(ccFolder, 'compile_cmd.json')
+        ];
+
+        this.databaseEvents.forEach(watch => watch.dispose());
+        this.databaseWatches.forEach(watch => watch.dispose());
+
+        this.databaseWatches = this.databasePaths
+            .filter(x => x !== undefined)
+            .map(path => workspace.createFileSystemWatcher(path!));
+
+        for (const watch of this.databaseWatches) {
+            this.databaseEvents.push(watch.onDidCreate(() => this._databaseLocationChanged.fire()));
+            this.databaseEvents.push(watch.onDidDelete(() => this._databaseLocationChanged.fire()));
+        }
+
+        this._databaseLocationChanged.fire();
     }
 
     private updateStatus(status: ProcessStatus) {
@@ -70,27 +129,7 @@ export class ExecutorProcess {
             return undefined;
         }
 
-        const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
-
-        const getConfigAndReplaceVariables = (category: string, name: string): string | undefined => {
-            const configValue = workspace.getConfiguration(category).get<string>(name);
-            return configValue
-                ?.replace(/\${workspaceRoot}/g, workspaceFolder)
-                .replace(/\${workspaceFolder}/g, workspaceFolder)
-                .replace(/\${cwd}/g, process.cwd())
-                .replace(/\${env\.([^}]+)}/g, (sub: string, envName: string) => process.env[envName] ?? '');
-        };
-
-        const ccFolder = getConfigAndReplaceVariables('codechecker.backend', 'outputFolder')
-            ?? path.join(workspaceFolder, '.codechecker');
-
-        const compileCmdPaths = [
-            getConfigAndReplaceVariables('codechecker.backend', 'databasePath'),
-            path.join(ccFolder, 'compile_commands.json'),
-            path.join(ccFolder, 'compile_cmd.json')
-        ];
-
-        for (const filePath of compileCmdPaths) {
+        for (const filePath of this.databasePaths) {
             if (filePath && fs.existsSync(filePath)) {
                 this._processStderr.fire(`>>> Database found at path: ${filePath}\n`);
                 return filePath;
@@ -98,7 +137,7 @@ export class ExecutorProcess {
         }
 
         this._processStderr.fire('>>> No database found in the following paths:\n');
-        for (const filePath of compileCmdPaths) {
+        for (const filePath of this.databasePaths) {
             if (filePath) {
                 this._processStderr.fire(`>>>   ${filePath}\n`);
             } else {

--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -102,7 +102,7 @@ export class ExecutorProcess {
             if (filePath) {
                 this._processStderr.fire(`>>>   ${filePath}\n`);
             } else {
-                this._processStderr.fire('>>>   <no path set in settings>');
+                this._processStderr.fire('>>>   <no path set in settings>\n');
             }
         }
 

--- a/src/backend/executor/triggers.ts
+++ b/src/backend/executor/triggers.ts
@@ -147,8 +147,10 @@ export class ExecutorManager implements Disposable {
 
     analyzeOnSave() {
         const canAnalyzeOnSave = workspace.getConfiguration('codechecker.executor').get<boolean>('runOnSave');
+        // Fail silently if there's no compile_commands.json
+        const ccExists = ExtensionApi.executorProcess.getCompileCommandsPath() !== undefined;
 
-        if (!canAnalyzeOnSave) {
+        if (!canAnalyzeOnSave || !ccExists) {
             return;
         }
 

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -1,6 +1,7 @@
 import { ExtensionContext } from 'vscode';
 import { DiagnosticRenderer } from './diagnostics';
 import { ExecutorAlerts } from './executor';
+import { FolderInitializer } from './initialize';
 import { LoggerPanel } from './logger';
 import { NavigationHandler } from './navigation';
 
@@ -10,6 +11,7 @@ export class Editor {
         this._navigationHandler = new NavigationHandler(ctx);
         this._loggerPanel = new LoggerPanel(ctx);
         this._executorAlerts = new ExecutorAlerts(ctx);
+        this._folderInitializer = new FolderInitializer(ctx);
     }
 
     private static _diagnosticRenderer: DiagnosticRenderer;
@@ -30,5 +32,10 @@ export class Editor {
     private static _executorAlerts: ExecutorAlerts;
     public static get executorAlerts(): ExecutorAlerts {
         return this._executorAlerts;
+    }
+
+    private static _folderInitializer: FolderInitializer;
+    public static get folderInitializer(): FolderInitializer {
+        return this._folderInitializer;
     }
 }

--- a/src/editor/initialize.ts
+++ b/src/editor/initialize.ts
@@ -25,8 +25,12 @@ export class FolderInitializer {
             return;
         }
 
+        const choiceMessage = ExtensionApi.executorProcess.getCompileCommandsPath() === undefined
+            ? 'Compilation database not found. How would you like to proceed?'
+            : 'Would you like to update the compilation database?';
+
         const choice = await window.showInformationMessage(
-            'compile_commands.json was not found in the CodeChecker folder. How would you like to proceed?',
+            choiceMessage,
             'Run CodeChecker log',
             'Locate',
             'Don\'t show again'

--- a/src/editor/initialize.ts
+++ b/src/editor/initialize.ts
@@ -1,0 +1,87 @@
+import { ExtensionContext, Uri, commands, window, workspace } from 'vscode';
+import { ExtensionApi } from '../backend';
+
+export class FolderInitializer {
+    constructor(_ctx: ExtensionContext) {
+        commands.registerCommand('codechecker.editor.showSetupDialog', this.showDialog, this);
+
+        this.showDialogIfAvailable()
+            .catch((err) => console.error(err));
+    }
+
+    async showDialogIfAvailable() {
+        if (
+            ExtensionApi.executorProcess.getCompileCommandsPath() === undefined &&
+            workspace.getConfiguration('codechecker.editor').get('showDatabaseDialog') !== false
+        ) {
+            this.showDialog();
+        }
+    }
+
+    async showDialog() {
+        const choice = await window.showInformationMessage(
+            'compile_commands.json was not found in the CodeChecker folder. How would you like to proceed?',
+            'Run CodeChecker log',
+            'Locate',
+            'Don\'t show again'
+        );
+
+        const workspaceFolder = workspace.workspaceFolders?.length && workspace.workspaceFolders[0].uri;
+
+        if (!workspaceFolder) {
+            return;
+        }
+
+        const getConfigAndReplaceVariables = (category: string, name: string): string | undefined => {
+            const configValue = workspace.getConfiguration(category).get<string>(name);
+            return configValue
+                ?.replace(/\${workspaceRoot}/g, workspaceFolder.fsPath)
+                .replace(/\${workspaceFolder}/g, workspaceFolder.fsPath)
+                .replace(/\${cwd}/g, process.cwd())
+                .replace(/\${env\.([^}]+)}/g, (sub: string, envName: string) => process.env[envName] ?? '');
+        };
+
+        const codeCheckerFolder = Uri.file(
+            getConfigAndReplaceVariables('codechecker.backend', 'outputFolder')
+            ?? Uri.joinPath(workspaceFolder, '.codechecker').fsPath
+        );
+
+        switch (choice) {
+        case 'Run CodeChecker log':
+            const cmdLine = ExtensionApi.executorProcess.getLogCmdLine();
+            if (cmdLine === undefined) {
+                break;
+            }
+
+            await workspace.fs.createDirectory(codeCheckerFolder);
+
+            const terminal = window.createTerminal('CodeChecker');
+            terminal.sendText(cmdLine, false);
+            terminal.show(false);
+
+            return;
+        case 'Locate':
+            const filePath = await window.showOpenDialog({ canSelectFiles: true });
+            if (!filePath || filePath.length === 0) {
+                break;
+            }
+
+            workspace.getConfiguration('codechecker.backend').update('databasePath', filePath);
+            return;
+        case 'Don\'t show again':
+            workspace.getConfiguration('codechecker.editor').update('showDatabaseDialog', false);
+            return;
+        default:
+            // Show again next time this workspace is opened
+            return;
+        }
+
+        // If initialization failed, show notification again
+        if (
+            ExtensionApi.executorProcess.getProcessCmdLine() === undefined &&
+            workspace.getConfiguration('codechecker.editor').get('showDatabaseDialog') !== false
+        ) {
+            await this.showDialog();
+        }
+    }
+}

--- a/src/sidebar/views/overview.ts
+++ b/src/sidebar/views/overview.ts
@@ -95,6 +95,7 @@ export class OverviewView implements TreeDataProvider<OverviewItem> {
     constructor(ctx: ExtensionContext) {
         ctx.subscriptions.push(this._onDidChangeTreeData = new EventEmitter());
         ExtensionApi.metadata.metadataUpdated(this.updateStats, this, ctx.subscriptions);
+        ExtensionApi.executorProcess.databaseLocationChanged(this.updateStats, this, ctx.subscriptions);
 
         this.itemsList = [this.topItems.loading];
 
@@ -114,7 +115,7 @@ export class OverviewView implements TreeDataProvider<OverviewItem> {
         }
     }
 
-    updateStats(_event?: CheckerMetadata) {
+    updateStats(_event?: CheckerMetadata | void) {
         const topItems = ExtensionApi.metadata.metadata !== undefined
             ? this.topItems.normal
             : this.topItems.notFound;

--- a/src/sidebar/views/overview.ts
+++ b/src/sidebar/views/overview.ts
@@ -16,96 +16,87 @@ export class OverviewItem {
     }
 }
 
-export class OverviewView implements TreeDataProvider<string> {
-    private tree?: TreeView<string>;
+export class OverviewView implements TreeDataProvider<OverviewItem> {
+    private tree?: TreeView<OverviewItem>;
 
-    // FIXME: Export the keys into an enum, or otherwise check in the itemsList if an entry exists
-    private items: {[id: string]: OverviewItem} = {
-        'loading': new OverviewItem('Loading overview, please wait...'),
+    private topItems: {[id: string]: OverviewItem[]} = {
+        'loading': [
+            new OverviewItem('Loading overview, please wait...')
+        ],
+        'notFound': [
+            new OverviewItem('CodeChecker run not found.'),
+            new OverviewItem('Run CodeChecker, reload metadata,'),
+            new OverviewItem('or set the output folder to get started')
+        ],
+        'normal': [
+            new OverviewItem(() => `Total files analyzed: ${ExtensionApi.metadata.sourceFiles.size}`),
+            new OverviewItem(() => `Last analysis run: ${
+                new Date(ExtensionApi.metadata.metadata!.timestamps.begin /* seconds */ * 1000).toLocaleString()
+            }`),
+            new OverviewItem(() => {
+                // Time in seconds
+                const beginTime = ExtensionApi.metadata.metadata!.timestamps.begin;
+                const endTime = ExtensionApi.metadata.metadata!.timestamps.end;
+                const interval = endTime - beginTime;
 
-        'notfound': new OverviewItem('CodeChecker run not found.'),
-        'notfound2': new OverviewItem('Run CodeChecker, reload metadata,'),
-        'notfound3': new OverviewItem('or set the output folder to get started'),
+                const hours = Math.floor(interval/3600) % 60;
+                const minutes = Math.floor(interval/60) % 60;
+                const seconds = Math.floor(interval) % 60;
+                const ms = Math.floor(interval * 1000) % 1000;
 
-        'files': new OverviewItem(() => `Total files analyzed: ${ExtensionApi.metadata.sourceFiles.size}`),
-        'lastRun': new OverviewItem(() => `Last analysis run: ${
-            new Date(ExtensionApi.metadata.metadata!.timestamps.begin /* seconds */ * 1000).toLocaleString()
-        }`),
-        'buildLength': new OverviewItem(() => {
-            // Time in seconds
-            const beginTime = ExtensionApi.metadata.metadata!.timestamps.begin;
-            const endTime = ExtensionApi.metadata.metadata!.timestamps.end;
-            const interval = endTime - beginTime;
-
-            const hours = Math.floor(interval/3600) % 60;
-            const minutes = Math.floor(interval/60) % 60;
-            const seconds = Math.floor(interval) % 60;
-            const ms = Math.floor(interval * 1000) % 1000;
-
-            if (hours > 0 || minutes > 0) {
-                // H:MM:SS s / M:SS s
-                const formattedMinutes = hours > 0 ? (`${hours}:${minutes.toString().padStart(2, '0')}`) : minutes;
-                return `Analysis duration: ${formattedMinutes}:${seconds.toString().padStart(2, '0')} s`;
-            } else {
-                // S.fff s
-                return `Analysis duration: ${(seconds + ms / 1000).toFixed(3)} s`;
-            }
-        }),
-        'analyzers': new OverviewItem(() => `Used analyzers: ${
-            Object.keys(ExtensionApi.metadata.metadata!.analyzers).join(', ')
-        }`),
-
-        'separator': new OverviewItem('——'),
-
-        'quickSetup': new OverviewItem('Show database setup dialog', {
-            title: 'showSetupDialog',
-            command: 'codechecker.editor.showSetupDialog'
-        }),
-        'reloadMetadata': new OverviewItem('Reload CodeChecker metadata', {
-            title: 'reloadMetadata',
-            command: 'codechecker.backend.reloadMetadata',
-        }),
-        'analyzeCurrentFile': new OverviewItem('Re-analyze current file', {
-            title: 'reloadMetadata',
-            command: 'codechecker.executor.analyzeCurrentFile',
-        }),
-        'analyzeProject': new OverviewItem('Re-analyze entire project', {
-            title: 'reloadMetadata',
-            command: 'codechecker.executor.analyzeProject',
-        }),
+                if (hours > 0 || minutes > 0) {
+                    // H:MM:SS s / M:SS s
+                    const formattedMinutes = hours > 0 ? (`${hours}:${minutes.toString().padStart(2, '0')}`) : minutes;
+                    return `Analysis duration: ${formattedMinutes}:${seconds.toString().padStart(2, '0')} s`;
+                } else {
+                    // S.fff s
+                    return `Analysis duration: ${(seconds + ms / 1000).toFixed(3)} s`;
+                }
+            }),
+            new OverviewItem(() => `Used analyzers: ${
+                Object.keys(ExtensionApi.metadata.metadata!.analyzers).join(', ')
+            }`),
+        ]
     };
 
-    private regularItemsList = [
-        'files',
-        'lastRun',
-        'buildLength',
-        'analyzers',
+    private bottomItems: {[id: string]: OverviewItem[]} = {
+        'normal': [
+            new OverviewItem('Reload CodeChecker metadata', {
+                title: 'reloadMetadata',
+                command: 'codechecker.backend.reloadMetadata',
+            }),
+            new OverviewItem('Re-analyze current file', {
+                title: 'reloadMetadata',
+                command: 'codechecker.executor.analyzeCurrentFile',
+            }),
+            new OverviewItem('Re-analyze entire project', {
+                title: 'reloadMetadata',
+                command: 'codechecker.executor.analyzeProject',
+            }),
+        ],
+        'ccNotFound': [
+            new OverviewItem('Compilation database not found.'),
+            new OverviewItem('Show database setup dialog...', {
+                title: 'showSetupDialog',
+                command: 'codechecker.editor.showSetupDialog'
+            }),
+            new OverviewItem('——'),
+            new OverviewItem('Reload CodeChecker metadata', {
+                title: 'reloadMetadata',
+                command: 'codechecker.backend.reloadMetadata',
+            }),
+        ]
+    };
 
-        'separator',
+    private separator = [new OverviewItem('——')];
 
-        'reloadMetadata',
-        'analyzeCurrentFile',
-        'analyzeProject',
-    ];
-    private notFoundItemsList = [
-        'notfound',
-        'notfound2',
-        'notfound3',
-
-        'separator',
-
-        'quickSetup',
-        'reloadMetadata',
-        'analyzeCurrentFile',
-        'analyzeProject',
-    ];
-    private itemsList: string[];
+    private itemsList: OverviewItem[][];
 
     constructor(ctx: ExtensionContext) {
         ctx.subscriptions.push(this._onDidChangeTreeData = new EventEmitter());
         ExtensionApi.metadata.metadataUpdated(this.updateStats, this, ctx.subscriptions);
 
-        this.itemsList = ['loading'];
+        this.itemsList = [this.topItems.loading];
 
         ctx.subscriptions.push(this.tree = window.createTreeView(
             'codechecker.views.overview',
@@ -124,11 +115,15 @@ export class OverviewView implements TreeDataProvider<string> {
     }
 
     updateStats(_event?: CheckerMetadata) {
-        if (ExtensionApi.metadata.metadata !== undefined) {
-            this.itemsList = this.regularItemsList;
-        } else {
-            this.itemsList = this.notFoundItemsList;
-        }
+        const topItems = ExtensionApi.metadata.metadata !== undefined
+            ? this.topItems.normal
+            : this.topItems.notFound;
+
+        const bottomItems = ExtensionApi.executorProcess.getCompileCommandsPath() !== undefined
+            ? this.bottomItems.normal
+            : this.bottomItems.ccNotFound;
+
+        this.itemsList = [topItems, this.separator, bottomItems];
 
         this._onDidChangeTreeData.fire();
     }
@@ -138,15 +133,15 @@ export class OverviewView implements TreeDataProvider<string> {
         return this._onDidChangeTreeData.event;
     }
 
-    getChildren(element?: string): string[] {
+    getChildren(element?: OverviewItem): OverviewItem[] {
         if (element !== undefined) {
             return [];
         }
 
-        return this.itemsList;
+        return this.itemsList.flat();
     }
 
-    getTreeItem(item: string): TreeItem | Promise<TreeItem> {
-        return this.items[item].getTreeItem();
+    getTreeItem(item: OverviewItem): TreeItem | Promise<TreeItem> {
+        return item.getTreeItem();
     }
 }

--- a/src/sidebar/views/overview.ts
+++ b/src/sidebar/views/overview.ts
@@ -57,6 +57,10 @@ export class OverviewView implements TreeDataProvider<string> {
 
         'separator': new OverviewItem('——'),
 
+        'quickSetup': new OverviewItem('Show database setup dialog', {
+            title: 'showSetupDialog',
+            command: 'codechecker.editor.showSetupDialog'
+        }),
         'reloadMetadata': new OverviewItem('Reload CodeChecker metadata', {
             title: 'reloadMetadata',
             command: 'codechecker.backend.reloadMetadata',
@@ -90,6 +94,7 @@ export class OverviewView implements TreeDataProvider<string> {
 
         'separator',
 
+        'quickSetup',
         'reloadMetadata',
         'analyzeCurrentFile',
         'analyzeProject',


### PR DESCRIPTION
Closes #15.

Currently the database setup dialog has 3 options:
* `Run CodeChecker log` creates a terminal, with a pre-defined `CodeChecker log` command already written there.
* `Locate` shows a file selector to select the database's path, eg. for CMake with a `/build` folder
* `Don't show again` never shows the window again on folder open.

The dialog shows when compile_commands.json is not found.
There's also a button in the Overview in an empty folder to select its path.

Currently there's no separation between missing the metadata.json and missing the compile_commands.json in the sidepanel.
I'd like to add a separate sidebar panel option for it before merging.