### PR TITLE
CodeLens support for repr. path

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Since CodeChecker-related paths vary greatly between systems, the following sett
 | CodeChecker > Backend > Output folder <br> (default: `${workspaceFolder}/.codechecker`) | The output folder where the CodeChecker analysis files are stored. |
 | CodeChecker > Backend > Database path <br> (default: *(empty)*) | Path to a custom compilation database, in case of a custom build system. The database setup dialog sets the path for the current workspace only. |
 | CodeChecker > Editor > Show database dialog <br> (default: `on`) | Controls the dialog when opening a workspace without a compilation database. |
+| CodeChecker > Editor > Enable CodeLens <br> (default: `on`) | Enable CodeLens for displaying the reproduction path in the editor. |
 | CodeChecker > Executor > Executable path <br> (default: `CodeChecker`) |  Path to the CodeChecker executable (can be an executable in the `PATH` environment variable). |
 | CodeChecker > Executor > Thread count <br> (default: *(empty)*) | CodeChecker's thread count - leave empty to use all threads. |
 | CodeChecker > Executor > Arguments <br> (default: *(empty)*) | Additional arguments to CodeChecker. For supported arguments, run `CodeChecker analyze --help`. <br> *Note:* The resulting command-line can be previewed with the command `CodeChecker: Show full command line`. |

--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
           "description": "Show a dialog if the compilation database is not found",
           "default": true
         },
+        "codechecker.editor.enableCodeLens": {
+          "type": "boolean",
+          "description": "Enable CodeLens for displaying the reproduction path",
+          "default": true
+        },
         "codechecker.executor.executablePath": {
           "type": "string",
           "description": "Path to CodeChecker's executable",

--- a/src/editor/codelens.ts
+++ b/src/editor/codelens.ts
@@ -1,0 +1,101 @@
+import {
+    CancellationToken,
+    CodeLens,
+    CodeLensProvider,
+    Event,
+    EventEmitter,
+    ExtensionContext,
+    Range,
+    TextDocument,
+    languages,
+    workspace
+} from 'vscode';
+import { ExtensionApi } from '../backend';
+import { AnalysisPathEvent, AnalysisPathKind } from '../backend/types';
+
+export class CodeLensStepsProvider implements CodeLensProvider {
+    constructor(ctx: ExtensionContext) {
+        ctx.subscriptions.push(this._onDidChangeCodeLenses = new EventEmitter());
+
+        ExtensionApi.diagnostics.diagnosticsUpdated(
+            this._onDidChangeCodeLenses.fire,
+            this._onDidChangeCodeLenses,
+            ctx.subscriptions
+        );
+
+        ctx.subscriptions.push(languages.registerCodeLensProvider('*', this));
+    }
+
+    private _onDidChangeCodeLenses: EventEmitter<void>;
+    public get onDidChangeCodeLenses(): Event<void> {
+        return this._onDidChangeCodeLenses.event;
+    }
+
+    provideCodeLenses(document: TextDocument, _token: CancellationToken): CodeLens[] {
+        if (ExtensionApi.diagnostics.selectedEntry === undefined ||
+            !workspace.getConfiguration('codechecker.editor').get('enableCodeLens')) {
+            return [];
+        }
+
+        const entry = ExtensionApi.diagnostics.selectedEntry;
+        const fullPath = entry.diagnostic.path
+            .filter(elem => elem.kind === AnalysisPathKind.Event) as AnalysisPathEvent[];
+
+        if (fullPath.length === 0) {
+            return [];
+        }
+
+        const codeLenses = [];
+
+        for (const [idx, pathItem] of fullPath.entries()) {
+            if (entry.diagnostic.files[pathItem.location.file] !== document.uri.fsPath) {
+                continue;
+            }
+
+            // TODO: Handle multiple ranges
+            const range = new Range(
+                pathItem.location.line-1,
+                pathItem.location.col-1,
+                pathItem.location.line-1,
+                pathItem.location.col,
+            );
+
+            // FIXME: Handle multiple steps in the same line
+            codeLenses.push(new CodeLens(range, {
+                'title': `${idx + 1}: ${pathItem.message}`,
+                'command': 'codechecker.editor.jumpToStep',
+                'arguments': [
+                    entry.position.file,
+                    entry.position.idx,
+                    idx
+                ]
+            }));
+
+            if (idx > 0) {
+                codeLenses.push(new CodeLens(range, {
+                    'title': 'Previous step',
+                    'command': 'codechecker.editor.jumpToStep',
+                    'arguments': [
+                        entry.position.file,
+                        entry.position.idx,
+                        idx - 1
+                    ]
+                }));
+            }
+
+            if (idx < fullPath.length - 1) {
+                codeLenses.push(new CodeLens(range, {
+                    'title': 'Next step',
+                    'command': 'codechecker.editor.jumpToStep',
+                    'arguments': [
+                        entry.position.file,
+                        entry.position.idx,
+                        idx + 1
+                    ]
+                }));
+            }
+        }
+
+        return codeLenses;
+    }
+}

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -1,4 +1,5 @@
 import { ExtensionContext } from 'vscode';
+import { CodeLensStepsProvider } from './codelens';
 import { DiagnosticRenderer } from './diagnostics';
 import { ExecutorAlerts } from './executor';
 import { FolderInitializer } from './initialize';
@@ -9,6 +10,7 @@ export class Editor {
     static init(ctx: ExtensionContext): void {
         this._diagnosticRenderer = new DiagnosticRenderer(ctx);
         this._navigationHandler = new NavigationHandler(ctx);
+        this._codeLensStepsProvider = new CodeLensStepsProvider(ctx);
         this._loggerPanel = new LoggerPanel(ctx);
         this._executorAlerts = new ExecutorAlerts(ctx);
         this._folderInitializer = new FolderInitializer(ctx);
@@ -17,6 +19,11 @@ export class Editor {
     private static _diagnosticRenderer: DiagnosticRenderer;
     public static get diagnosticRenderer(): DiagnosticRenderer {
         return this._diagnosticRenderer;
+    }
+
+    private static _codeLensStepsProvider: CodeLensStepsProvider;
+    public static get codeLensStepsProvider(): CodeLensStepsProvider {
+        return this._codeLensStepsProvider;
     }
 
     private static _navigationHandler: NavigationHandler;


### PR DESCRIPTION
Adds CodeLens to the reproduction path in the editor, making the flow much clearer.

![image](https://user-images.githubusercontent.com/16914176/141748453-0ce1799a-0c48-4c50-9dee-43ca4471fb97.png)
