### PR TITLE
Use matrix strategy at deploy github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,26 @@ on:
 
 jobs:
   build:
-    name: Build and publish extension
+    name: Create extension
     runs-on: ubuntu-18.04
+
+    # Each registry should have the following fields:
+    #   - name: unique extension id.
+    #   - registryUrl: the created vsix package will be published to this registry.
+    #   - token: github secret name which will be used to publish the created package.
+    strategy:
+      matrix:
+        registry: [open-vsx, vs-marketplace]
+        include:
+          - registry: open-vsx
+            name: codechecker
+            registryUrl: https://open-vsx.org
+            token: OPEN_VSX_TOKEN
+          - registry: vs-marketplace
+            name: vscode-codechecker
+            registryUrl: https://marketplace.visualstudio.com
+            token: VS_MARKETPLACE_TOKEN
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -34,6 +52,7 @@ jobs:
         if: success()
         id: build
         run: |
+          sed -i 's/"name": "codechecker"/"name": "${{ matrix.name }}"/' package.json
           yarn run vsce package --no-git-tag-version --yarn ${{ steps.get_version.outputs.VERSION }}
           echo ::set-output name=vsixPath::$(readlink -f *.vsix)
 
@@ -41,20 +60,13 @@ jobs:
         if: success()
         uses: actions/upload-artifact@master
         with:
-          name: vsix-package
+          name: ${{ matrix.registry }}-package
           path: ${{ steps.build.outputs.vsixPath }}
 
-      - name: Publish to Open VSX Registry
+      - name: Publish package
         if: success()
         uses: HaaLeo/publish-vscode-extension@v1
         with:
-          pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: ${{ steps.build.outputs.vsixPath }}
-
-      - name: Publish to Visual Studio Marketplace
-        if: success()
-        uses: HaaLeo/publish-vscode-extension@v1
-        with:
-          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
-          registryUrl: https://marketplace.visualstudio.com
+          pat: ${{ secrets[matrix.token] }}
+          registryUrl: ${{ matrix.registryUrl }}
           extensionFile: ${{ steps.build.outputs.vsixPath }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a C/C++ code analysis plugin for VSCode that shows bug reports detected 
 4. Open your project, and run an analysis, or browse through the found reports!
 
 [Install CodeChecker]: https://github.com/Ericsson/CodeChecker#install-guide
-[Visual Studio Marketplace]: https://marketplace.visualstudio.com/items?itemName=codechecker.codechecker
+[Visual Studio Marketplace]: https://marketplace.visualstudio.com/items?itemName=codechecker.vscode-codechecker
 [Open VSX]: https://open-vsx.org/extension/codechecker/codechecker
 [Downloads]: https://github.com/Ericsson/CodecheckerVSCodePlugin/releases
 [Configuring CodeChecker]: #configuring-codechecker


### PR DESCRIPTION
Use matrix strategy in `deploy.yml` github action to create and publish
package to `OpenVSX` and `Visual Studio Marketplace`.

It will use the following unique extension ids for registries:
- `OpenVSX`: `codechecker`
- `VS Marketplace`: `vscode-codechecker`

**Note**: unfortunately we can't use the same extension id for these two
registries because will get the following error message when the package
is published to the registry:
`The Extension Id already exist in the Marketplace. Please use the different Id`

Both package will be published under the `codechecker` organization.