### PR TITLE
Remove `fast-plist` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,9 +207,6 @@
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js"
   },
-  "dependencies": {
-    "fast-plist": "^0.1.2"
-  },
   "devDependencies": {
     "@types/vscode": "^1.55.0",
     "@types/glob": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,11 +1066,6 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-plist@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/fast-plist/-/fast-plist-0.1.2.tgz#a45aff345196006d406ca6cdcd05f69051ef35b8"
-  integrity sha1-pFr/NFGWAG1AbKbNzQX2kFHvNbg=
-
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"


### PR DESCRIPTION
`fast-plist` dependency is not used anymore (we are using `CodeChecker parse` command to process analyzer result files) so we can remove it.