### PR TITLE
Wait for terminal initialization for CodeChecker log command

### DIFF
--- a/src/editor/initialize.ts
+++ b/src/editor/initialize.ts
@@ -55,8 +55,13 @@ export class FolderInitializer {
             await workspace.fs.createDirectory(codeCheckerFolder);
 
             const terminal = window.createTerminal('CodeChecker');
-            terminal.sendText(ExtensionApi.executorBridge.getLogCmdLine()!, false);
             terminal.show(false);
+
+            // Wait some time until the terminal is initialized properly. For now there is no elegant solution to solve
+            // this problem than using setTimeout.
+            setTimeout(() => {
+                terminal.sendText(ExtensionApi.executorBridge.getLogCmdLine()!, false);
+            }, 1000);
 
             return;
         case 'Locate':


### PR DESCRIPTION
> Closes #50

Wait some time until the terminal is initialized properly when getting `CodeChecker log` command.

For now there is no elegant solution for this problem than to wait some time by using `setTimeout` function.