### PR TITLE
Refactor executor to pass shell arguments as array

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Since CodeChecker-related paths vary greatly between systems, the following sett
 | CodeChecker > Backend > Compilation database path <br> (default: *(empty)*) | Path to a custom compilation database, in case of a custom build system. The database setup dialog sets the path for the current workspace only. |
 | CodeChecker > Editor > Show database dialog <br> (default: `on`) | Controls the dialog when opening a workspace without a compilation database. |
 | CodeChecker > Editor > Enable CodeLens <br> (default: `on`) | Enable CodeLens for displaying the reproduction path in the editor. |
-| CodeChecker > Executor > Executable path <br> (default: `CodeChecker`) |  Path to the CodeChecker executable (can be an executable in the `PATH` environment variable). |
+| CodeChecker > Executor > Executable path <br> (default: `CodeChecker`) | Path to the CodeChecker executable. Can be an executable in the `PATH` environment variable, or an absolute path to one. |
 | CodeChecker > Executor > Thread count <br> (default: *(empty)*) | CodeChecker's thread count - leave empty to use all threads. |
 | CodeChecker > Executor > Arguments <br> (default: *(empty)*) | Additional arguments to CodeChecker. For example, if you want to use a config file for CodeChecker pass '--config <config.json>'. For supported arguments, run `CodeChecker analyze --help`. <br> *Note:* The resulting command-line can be previewed with the command `CodeChecker: Show full command line`. |
 | CodeChecker > Executor > Run on save <br> (default: `on`) | Controls auto-run of CodeChecker on saving a file. |

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.11.7",
+    "@types/shell-quote": "^1.7.1",
     "eslint": "^7.19.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
@@ -248,5 +249,8 @@
     "vsce": "^1.100.1",
     "webpack": "^5.19.0",
     "webpack-cli": "^4.4.0"
+  },
+  "dependencies": {
+    "shell-quote": "^1.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
       "properties": {
         "codechecker.executor.executablePath": {
           "type": "string",
-          "description": "Path to CodeChecker's executable",
+          "description": "Path to CodeChecker's executable. Can be an executable in the `PATH` environment variable, or an absolute path to one.",
           "default": "CodeChecker",
           "order": 1
         },

--- a/package.json
+++ b/package.json
@@ -95,10 +95,7 @@
           "order": 2
         },
         "codechecker.backend.compilationDatabasePath": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "description": "Path to a custom compilation database, in case of a custom build system",
           "default": null,
           "order": 3

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -264,7 +264,7 @@ export class ExecutorBridge implements Disposable {
             return;
         }
 
-        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') ?? 'CodeChecker';
+        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') || 'CodeChecker';
         const commandArgs = this.getAnalyzeCmdArgs(file);
 
         if (commandArgs === undefined) {
@@ -284,7 +284,7 @@ export class ExecutorBridge implements Disposable {
         // Kill the process, since the entire project is getting analyzed anyways
         this.stopAnalysis();
 
-        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') ?? 'CodeChecker';
+        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') || 'CodeChecker';
         const commandArgs = this.getAnalyzeCmdArgs();
 
         if (commandArgs === undefined) {
@@ -309,7 +309,7 @@ export class ExecutorBridge implements Disposable {
             return;
         }
 
-        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') ?? 'CodeChecker';
+        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') || 'CodeChecker';
         const commandArgs = this.getParseCmdArgs(...files);
 
         if (commandArgs === undefined) {
@@ -339,7 +339,7 @@ export class ExecutorBridge implements Disposable {
                 return;
             }
 
-            const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') ?? 'CodeChecker';
+            const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') || 'CodeChecker';
             const commandArgs = this.getVersionCmdArgs();
 
             if (commandArgs === undefined) {

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -130,12 +130,10 @@ export class ExecutorBridge implements Disposable {
         // TODO: Refactor for less code repetition across functions
         const reportsFolder = this.getReportsFolder();
 
-        const ccArgumentsSetting = workspace.getConfiguration('codechecker.executor').get<string|string[]>('arguments');
-        const ccArguments = typeof ccArgumentsSetting === 'string'
-            ? parse(ccArgumentsSetting).filter((entry) => typeof entry === 'string') as string[]
-            : ccArgumentsSetting
-                ?.map((arg) => replaceVariables(arg))
-                .filter((arg) => arg !== undefined) as string[] ?? [];
+        const ccArgumentsSetting = workspace.getConfiguration('codechecker.executor').get<string>('arguments');
+        const ccArguments = parse(ccArgumentsSetting ?? '')
+            .filter((entry) => typeof entry === 'string')
+            .map((entry) => replaceVariables(entry as string)!);
 
         const ccThreads = workspace.getConfiguration('codechecker.executor').get<string>('threadCount');
         const ccCompileCmd = this.getCompileCommandsPath();

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -132,7 +132,7 @@ export class ExecutorBridge implements Disposable {
 
         const ccArgumentsSetting = workspace.getConfiguration('codechecker.executor').get<string>('arguments');
         const ccArguments = parse(ccArgumentsSetting ?? '')
-            .filter((entry) => typeof entry === 'string')
+            .filter((entry) => typeof entry === 'string' && entry.length > 0)
             .map((entry) => replaceVariables(entry as string)!);
 
         const ccThreads = workspace.getConfiguration('codechecker.executor').get<string>('threadCount');

--- a/src/editor/executor.ts
+++ b/src/editor/executor.ts
@@ -33,7 +33,7 @@ export class ExecutorAlerts {
     }
 
     printCmdLine() {
-        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') ?? 'CodeChecker';
+        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') || 'CodeChecker';
         const commandLine = quote([
             ccPath,
             ...ExtensionApi.executorBridge.getAnalyzeCmdArgs() ?? []

--- a/src/editor/executor.ts
+++ b/src/editor/executor.ts
@@ -1,3 +1,4 @@
+import { quote } from 'shell-quote';
 import {
     ExtensionContext,
     StatusBarAlignment,
@@ -8,6 +9,7 @@ import {
 import { Editor } from '.';
 import { ExtensionApi } from '../backend';
 import { ProcessStatus } from '../backend/executor/process';
+import { getConfigAndReplaceVariables } from '../utils/config';
 
 export class ExecutorAlerts {
     private statusBarItem: StatusBarItem;
@@ -31,7 +33,12 @@ export class ExecutorAlerts {
     }
 
     printCmdLine() {
-        const commandLine = ExtensionApi.executorBridge.getAnalyzeCmdLine();
+        const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') ?? 'CodeChecker';
+        const commandLine = quote([
+            ccPath,
+            ...ExtensionApi.executorBridge.getAnalyzeCmdArgs() ?? []
+        ]);
+
         Editor.loggerPanel.window.appendLine('>>> Full command line:');
         Editor.loggerPanel.window.appendLine(`>>> ${commandLine}`);
 

--- a/src/editor/initialize.ts
+++ b/src/editor/initialize.ts
@@ -55,7 +55,7 @@ export class FolderInitializer {
         case 'Run CodeChecker log':
             await workspace.fs.createDirectory(codeCheckerFolder);
 
-            const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') ?? 'CodeChecker';
+            const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') || 'CodeChecker';
             const commandLine = quote([
                 ccPath,
                 ...ExtensionApi.executorBridge.getLogCmdArgs()!

--- a/src/editor/initialize.ts
+++ b/src/editor/initialize.ts
@@ -1,4 +1,5 @@
 import { ExtensionContext, Uri, commands, window, workspace } from 'vscode';
+import { quote } from 'shell-quote';
 import { ExtensionApi } from '../backend';
 
 export class FolderInitializer {
@@ -54,13 +55,19 @@ export class FolderInitializer {
         case 'Run CodeChecker log':
             await workspace.fs.createDirectory(codeCheckerFolder);
 
+            const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') ?? 'CodeChecker';
+            const commandLine = quote([
+                ccPath,
+                ...ExtensionApi.executorBridge.getLogCmdArgs()!
+            ]);
+
             const terminal = window.createTerminal('CodeChecker');
             terminal.show(false);
 
             // Wait some time until the terminal is initialized properly. For now there is no elegant solution to solve
             // this problem than using setTimeout.
             setTimeout(() => {
-                terminal.sendText(ExtensionApi.executorBridge.getLogCmdLine()!, false);
+                terminal.sendText(commandLine, false);
             }, 1000);
 
             return;
@@ -82,7 +89,7 @@ export class FolderInitializer {
 
         // If initialization failed, show notification again
         if (
-            ExtensionApi.executorBridge.getAnalyzeCmdLine() === undefined &&
+            ExtensionApi.executorBridge.getAnalyzeCmdArgs() === undefined &&
             workspace.getConfiguration('codechecker.editor').get('showDatabaseDialog') !== false
         ) {
             await this.showDialog();

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,14 +1,19 @@
 import { workspace } from 'vscode';
 
 export function getConfigAndReplaceVariables(category: string, name: string): string | undefined {
+    const configValue = workspace.getConfiguration(category).get<string>(name);
+
+    return replaceVariables(configValue);
+}
+
+export function replaceVariables(pathLike?: string): string | undefined {
     if (!workspace.workspaceFolders) {
         return;
     }
 
     const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
 
-    const configValue = workspace.getConfiguration(category).get<string>(name);
-    return configValue
+    return pathLike
         ?.replace(/\${workspaceRoot}/g, workspaceFolder)
         .replace(/\${workspaceFolder}/g, workspaceFolder)
         .replace(/\${cwd}/g, process.cwd())

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,6 +128,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8"
   integrity sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==
 
+"@types/shell-quote@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@types/shell-quote/-/shell-quote-1.7.1.tgz#2d059091214a02c29f003f591032172b2aff77e8"
+  integrity sha512-SWZ2Nom1pkyXCDohRSrkSKvDh8QOG9RfAsrt5/NsPQC4UQJ55eG0qClA40I+Gkez4KTQ0uDUT8ELRXThf3J5jw==
+
 "@types/vscode@1.53.0":
   version "1.53.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.53.0.tgz#47b53717af6562f2ad05171bc9c8500824a3905c"
@@ -2135,6 +2140,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
+  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Closes #56.

Previously, we `.join(' ')`-ed the executor arguments. With this refactor, the executor no longer constructs the full command-line, but rather directly passes the args array to `child_process.spawn`.

For the user-facing input (arguments setting) and output (command-line preview), the [`shell-quote`](https://www.npmjs.com/package/shell-quote) package is used.