### PR TITLE
Fix adding selectedEntry to openedFiles

### DIFF
--- a/src/backend/processor/diagnostics.ts
+++ b/src/backend/processor/diagnostics.ts
@@ -70,7 +70,7 @@ export class DiagnosticsApi {
 
     public reloadDiagnostics() {
         // TODO: Allow loading all diagnostics at once
-        const filesToLoad = this._openedFiles;
+        const filesToLoad = [...this._openedFiles];
 
         if (this._selectedEntry) {
             filesToLoad.push(this._selectedEntry.file);


### PR DESCRIPTION
When pressing Reload CodeChecker metadata many times, many instances of the currently opened report's file are getting added to the currently open files due to a pass-by-reference bug.

![image](https://user-images.githubusercontent.com/16914176/151554339-17a5cf1d-7728-45d0-be73-d0ed7d9eb033.png)
