### PR TITLE
Remove unclosable CodeChecker analysis in progress window

### DIFF
--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -21,8 +21,7 @@ export enum ProcessType {
 export interface ProcessParameters {
     /** Default: true, false when type is parse */
     forwardStdoutToLogs?: boolean,
-    /** Default: true, false when type is parse or version */
-    showProgressBar?: boolean,
+
     /**
      * Name of the process, preferred to be one of ProcessType.
      * Default: other
@@ -78,14 +77,9 @@ export class ScheduledProcess implements Disposable {
         this.processParameters = parameters;
 
         const forwardDefaults: string[] = [ ProcessType.parse ];
-        const progressDefaults: string[] = [ ProcessType.parse, ProcessType.version ];
 
         if (this.processParameters.forwardStdoutToLogs === undefined) {
             this.processParameters.forwardStdoutToLogs = !forwardDefaults.includes(parameters.processType ?? '');
-        }
-
-        if (this.processParameters.showProgressBar === undefined) {
-            this.processParameters.showProgressBar = !progressDefaults.includes(parameters.processType ?? '');
         }
     }
 

--- a/src/sidebar/views/overview.ts
+++ b/src/sidebar/views/overview.ts
@@ -106,6 +106,14 @@ export class OverviewView implements TreeDataProvider<OverviewItem> {
                     command: 'codechecker.executor.analyzeProject',
                 }
             ),
+            new OverviewItem(
+                'Stop analysis',
+                'debug-stop',
+                {
+                    title: 'stopAnalysis',
+                    command: 'codechecker.executor.stopAnalysis',
+                }
+            ),
         ],
         'ccNotFound': [
             new OverviewItem(


### PR DESCRIPTION
> Closes #61

On large projects the analysis may take minutes. In this case it is
really annyoing for the user to show an unclosable pop-window.

Also this information whether an analysis is running is already available
in the bottom bar.

This patch will remove this pop-up window but will introduce a new tree
item on the overview sidebar to stop the analysis.