### PR TITLE
Fix showing output channel

### DIFF
--- a/src/editor/logger.ts
+++ b/src/editor/logger.ts
@@ -17,7 +17,10 @@ export class LoggerPanel {
     }
 
     showOutputTab() {
+        // Hiding and re-showing the window resets the auto-scroll state.
         this.window.hide();
-        this.window.show(false);
+
+        // setTimeout is needed to make sure Theia will show the correct output channel.
+        setTimeout(() => this.window.show(false), 0);
     }
 }


### PR DESCRIPTION
> Closes #78

Using `setTimeout` is needed because of `Theia` editor and it will make sure that the editor will show the window properly.