### PR TITLE
Bump up version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/Ericsson/CodeCheckerVSCodePlugin/issues"
   },
   "license": "Apache-2.0",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.55.0"
   },


### PR DESCRIPTION
The next release will contain not only bug fixes but other improvements as well. So for this reason the next version should be `1.2.0` instead of `1.1.1`.