### PR TITLE
Change CodeChecker analysis output to .codechecker/reports

### DIFF
--- a/src/backend/processor/metadata.ts
+++ b/src/backend/processor/metadata.ts
@@ -10,6 +10,7 @@ import {
     window,
     workspace
 } from 'vscode';
+import * as path from 'path';
 import { parseMetadata } from '../parser';
 import { CheckerMetadata } from '../types';
 
@@ -71,7 +72,8 @@ export class MetadataApi implements Disposable {
     private updateMetadataPath() {
         this.disposeWatcher();
 
-        this.metadataPath = workspace.getConfiguration('codechecker.backend').get<string>('outputFolder');
+        const ccFolder = workspace.getConfiguration('codechecker.backend').get<string>('outputFolder');
+        this.metadataPath = ccFolder && path.join(ccFolder, 'reports');
 
         if (this.metadataPath && workspace.workspaceFolders?.length) {
             const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;


### PR DESCRIPTION
> Closes #89

`.codechecker` directory may contain compilation database which is generated by the `CodeChecker log` command. It may also contain other files in the future. For this reason I recommend to change the output folder of the `CodeChecker analyze` command to `.codechecker/reports`.