### PR TITLE
Change value of version process type to analyzer-version

### DIFF
--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -15,7 +15,7 @@ export enum ProcessStatus {
 export enum ProcessType {
     analyze = 'CodeChecker analyze',
     parse = 'CodeChecker parse',
-    version = 'CodeChecker version',
+    version = 'CodeChecker analyzer-version',
     other = 'Other process',
 }
 


### PR DESCRIPTION
When an exception happens during calling the `CodeChecker analyzer-version`
command we print out the process type value. It is missleading to print out
that `CodeChecker version` is failed because we have called the
`CodeChecker analyzer-version`. For this reason in this commit we change
the value of this process type.