### PR TITLE
Expand user in the CodeChecker binary path

### DIFF
--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -1,4 +1,5 @@
 import * as child_process from 'child_process';
+import * as os from 'os';
 import { quote } from 'shell-quote';
 import { Disposable, Event, EventEmitter, ExtensionContext, workspace } from 'vscode';
 
@@ -17,6 +18,13 @@ export enum ProcessType {
     parse = 'CodeChecker parse',
     version = 'CodeChecker version',
     other = 'Other process',
+}
+
+const homeDir = os.homedir();
+
+// Expand an initial '~' component in the given path if there is any, otherwise returns the file path without changes.
+function expandUser(filePath: string) {
+    return homeDir ? filePath.replace(/^~(?=$|\/|\\)/, homeDir) : filePath;
 }
 
 export interface ProcessParameters {
@@ -84,7 +92,7 @@ export class ScheduledProcess implements Disposable {
     }
 
     constructor(executable: string, commandArgs?: string[], parameters?: ProcessParameters) {
-        this.executable = executable;
+        this.executable = expandUser(executable);
         this.commandArgs = commandArgs ?? [];
         this.processParameters = parameters ?? {};
 


### PR DESCRIPTION
We are using `spawn` method to execute a CodeChecker command.
If the executable path starts with a `~` (e.g.: `~/CodeChecker/bin/CodeChecker`),
the `spawn` method doesn't work properly and will give an exception.

For more information see: nodejs/node#684

To solve this problem we will expand the `~` in the file path before
executing the command.