### PR TITLE
Minor fixes

### DIFF
--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -332,6 +332,14 @@ export class ExecutorBridge implements Disposable {
         ExtensionApi.executorManager.addToQueue(process, 'replace');
     }
 
+    public async stopMetadataTasks() {
+        ExtensionApi.executorManager.clearQueue(ProcessType.parse);
+
+        if (ExtensionApi.executorManager.activeProcess?.processParameters.processType === ProcessType.parse) {
+            ExtensionApi.executorManager.killProcess();
+        }
+    }
+
     public async checkVersion(): Promise<boolean> {
         return new Promise((res, _rej) => {
             if (this.versionChecked) {
@@ -346,6 +354,7 @@ export class ExecutorBridge implements Disposable {
                 this._bridgeMessages.fire('>>> Unable to determine CodeChecker version commandline\n');
 
                 this.versionChecked = false;
+                res(this.versionChecked);
                 return;
             }
 
@@ -502,8 +511,6 @@ export class ExecutorBridge implements Disposable {
         if (!workspace.workspaceFolders?.length) {
             return;
         }
-
-        this.versionChecked = false;
 
         const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
 

--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -283,8 +283,11 @@ export class ExecutorManager implements Disposable {
         let namedQueue = this.queue.get(name) ?? [];
 
         // When adding the same process as the currently running one, assume that its underlying data was changed,
-        // and kill the currently active process
-        if (this.activeProcess?.commandLine === process.commandLine) {
+        // and kill the currently active process. Does not apply to the version check, as it reads no persistent data.
+        if (
+            this.activeProcess?.commandLine === process.commandLine &&
+            this.activeProcess?.processParameters.processType !== ProcessType.version
+        ) {
             this.killProcess();
         }
 

--- a/src/backend/processor/diagnostics.ts
+++ b/src/backend/processor/diagnostics.ts
@@ -78,6 +78,7 @@ export class DiagnosticsApi {
 
         // Unload reports without calling parse
         if (filesToLoad.length === 0) {
+            ExtensionApi.executorBridge.stopMetadataTasks();
             this._diagnosticEntries = new Map();
             this._diagnosticsUpdated.fire();
 


### PR DESCRIPTION
* Clear queued parse tasks when no files are open
* Fix some version-check cases that stalled the task queue, or made redundant version checks
* `CodeChecker version` is no longer deduplicated in the process queue