### PR TITLE
Refactor keyboard navigation

### DIFF
--- a/src/test/staticFiles/workspace/file.cpp
+++ b/src/test/staticFiles/workspace/file.cpp
@@ -1,9 +1,5 @@
 #include "file.h"
 
 int main() {
-  return foo();
-}
-
-int bar(int param) {
-  return 1 / param;
+  return 1 / foo(0);
 }

--- a/src/test/staticFiles/workspace/file.h
+++ b/src/test/staticFiles/workspace/file.h
@@ -1,10 +1,8 @@
 #ifndef FILE_H
 #define FILE_H
 
-int bar(int param);
-
-int foo() {
-  return bar(0);
+int foo(int x) {
+  return x;
 }
 
 #endif


### PR DESCRIPTION
Fixes #86.

The previously jumped-to step is stored, and future keyboard navigation will be based on that step.
Falls back to the old mechanism when there's no jumped-to step yet.