### PR TITLE
Integrate `CodeChecker log` into executor

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
         "title": "CodeChecker: Run CodeChecker log with a custom build command..."
       },
       {
+        "command": "codechecker.executor.previewLogInTerminal",
+        "title": "CodeChecker: Preview CodeChecker log in terminal"
+      },
+      {
         "command": "codechecker.executor.showOutput",
         "title": "CodeChecker: Show Output"
       },

--- a/package.json
+++ b/package.json
@@ -68,15 +68,23 @@
       },
       {
         "command": "codechecker.executor.showCommandLine",
-        "title": "CodeChecker: Show full command line"
+        "title": "CodeChecker: Show full CodeChecker analyze command line"
       },
       {
-        "command": "codechecker.logging.showOutput",
+        "command": "codechecker.executor.runCodeCheckerLog",
+        "title": "CodeChecker: Run CodeChecker log"
+      },
+      {
+        "command": "codechecker.executor.runLogWithBuildCommand",
+        "title": "CodeChecker: Run CodeChecker log with a custom build command..."
+      },
+      {
+        "command": "codechecker.executor.showOutput",
         "title": "CodeChecker: Show Output"
       },
       {
-        "command": "codechecker.executor.stopAnalysis",
-        "title": "CodeChecker: Stop analysis"
+        "command": "codechecker.executor.stopCodeChecker",
+        "title": "CodeChecker: Stop running CodeChecker instance"
       }
     ],
     "configuration": {
@@ -115,6 +123,18 @@
           "default": null,
           "minimum": 1,
           "order": 5
+        },
+        "codechecker.executor.logBuildCommand": {
+          "type": "string",
+          "description": "The build command passed to CodeChecker log.",
+          "default": "make",
+          "order": 6
+        },
+        "codechecker.executor.logArguments": {
+          "type": "string",
+          "description": "Additional arguments to CodeChecker log command. For supported arguments, run `CodeChecker log --help`. The command `CodeChecker: Preview CodeChecker log in terminal` command shows the resulting command line.",
+          "default": "",
+          "order": 7
         },
         "codechecker.editor.showDatabaseDialog": {
           "type": "boolean",
@@ -156,7 +176,7 @@
         "properties": {
           "taskType": {
             "type": "string",
-            "description": "The type of the CodeChecker task",
+            "description": "The type of the CodeChecker analysis task",
             "enum": [
               "project",
               "currentFile",

--- a/package.json
+++ b/package.json
@@ -192,6 +192,19 @@
             "description": "When using type `selectedFiles`, analyze the selected files."
           }
         }
+      },
+      {
+        "type": "CodeChecker log",
+        "required": [],
+        "properties": {
+          "buildCommand": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional custom build command for CodeChecker log"
+          }
+        }
       }
     ],
     "viewsContainers": {

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -12,9 +12,8 @@ import {
 import * as fs from 'fs';
 import * as path from 'path';
 import { ExtensionApi } from '../api';
-import { getConfigAndReplaceVariables, replaceVariables } from '../../utils/config';
+import { getConfigAndReplaceVariables, parseShellArgsAndReplaceVariables } from '../../utils/config';
 import { ProcessStatus, ProcessType, ScheduledProcess } from '.';
-import { parse } from 'shell-quote';
 
 // Structure:
 //   CodeChecker analyzer version: \n {"base_package_version": "M.m.p", ...}
@@ -127,28 +126,11 @@ export class ExecutorBridge implements Disposable {
             return undefined;
         }
 
-        const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
-
-        // TODO: Refactor for less code repetition across functions
         const reportsFolder = this.getReportsFolder();
 
         const ccArgumentsSetting = workspace.getConfiguration('codechecker.executor').get<string>('arguments');
 
-        // TODO: Merge this collection with replaceVariables
-        const env: { [key: string]: string } = {
-            workspaceFolder,
-            workspaceRoot: workspaceFolder,
-            cwd: process.cwd()
-        };
-        for (const [key, val] of Object.entries(process.env)) {
-            if (val !== undefined) {
-                env[`env:${key}`] = val;
-            }
-        }
-
-        const ccArguments = parse(ccArgumentsSetting ?? '', env)
-            .filter((entry) => typeof entry === 'string' && entry.length > 0)
-            .map((entry) => replaceVariables(entry as string)!);
+        const ccArguments = parseShellArgsAndReplaceVariables(ccArgumentsSetting ?? '');
 
         const ccThreads = workspace.getConfiguration('codechecker.executor').get<string>('threadCount');
         const ccCompileCmd = this.getCompileCommandsPath();

--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -15,6 +15,7 @@ export enum ProcessStatus {
 
 export enum ProcessType {
     analyze = 'CodeChecker analyze',
+    log = 'CodeChecker log',
     parse = 'CodeChecker parse',
     version = 'CodeChecker analyzer-version',
     other = 'Other process',
@@ -131,7 +132,11 @@ export class ScheduledProcess implements Disposable {
 
         this._processStderr.fire(`>>> Starting process '${commonName}'\n`);
         this._processStderr.fire(`> ${this.commandLine}\n`);
-        this.activeProcess = child_process.spawn(this.executable, this.commandArgs);
+        this.activeProcess = child_process.spawn(
+            this.executable,
+            this.commandArgs,
+            { cwd: workspace.workspaceFolders[0].uri.fsPath }
+        );
 
         this.activeProcess.stdout!.on('data', (stdout: Buffer) => {
             const decoded = stdout.toString();

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -5,7 +5,7 @@ import { ExecutorAlerts } from './executor';
 import { FolderInitializer } from './initialize';
 import { LoggerPanel } from './logger';
 import { NavigationHandler } from './navigation';
-import { ExecutorTaskProvider } from './tasks';
+import { AnalyzeTaskProvider, LogTaskProvider } from './tasks';
 
 export class Editor {
     static init(ctx: ExtensionContext): void {
@@ -15,7 +15,8 @@ export class Editor {
         this._loggerPanel = new LoggerPanel(ctx);
         this._executorAlerts = new ExecutorAlerts(ctx);
         this._folderInitializer = new FolderInitializer(ctx);
-        this._executorTaskProvider = new ExecutorTaskProvider(ctx);
+        this._analyzeTaskProvider = new AnalyzeTaskProvider(ctx);
+        this._logTaskProvider = new LogTaskProvider(ctx);
     }
 
     private static _diagnosticRenderer: DiagnosticRenderer;
@@ -48,8 +49,13 @@ export class Editor {
         return this._folderInitializer;
     }
 
-    private static _executorTaskProvider: ExecutorTaskProvider;
-    public static get executorTaskProvider(): ExecutorTaskProvider {
-        return this._executorTaskProvider;
+    private static _analyzeTaskProvider: AnalyzeTaskProvider;
+    public static get analyzeTaskProvider(): AnalyzeTaskProvider {
+        return this._analyzeTaskProvider;
+    }
+
+    private static _logTaskProvider: LogTaskProvider;
+    public static get logTaskProvider(): LogTaskProvider {
+        return this._logTaskProvider;
     }
 }

--- a/src/sidebar/views/overview.ts
+++ b/src/sidebar/views/overview.ts
@@ -107,6 +107,22 @@ export class OverviewView implements TreeDataProvider<OverviewItem> {
                 }
             ),
             new OverviewItem(
+                'Re-run CodeChecker log',
+                'list-flat',
+                {
+                    title: 'runCodeCheckerLog',
+                    command: 'codechecker.executor.runCodeCheckerLog'
+                }
+            ),
+            new OverviewItem(
+                'Preview CodeChecker log in terminal',
+                'terminal',
+                {
+                    title: 'previewLogInTerminal',
+                    command: 'codechecker.executor.previewLogInTerminal'
+                }
+            ),
+            new OverviewItem(
                 'Stop analysis',
                 'debug-stop',
                 {
@@ -131,6 +147,22 @@ export class OverviewView implements TreeDataProvider<OverviewItem> {
                 {
                     title: 'reloadMetadata',
                     command: 'codechecker.backend.reloadMetadata',
+                }
+            ),
+            new OverviewItem(
+                'Run CodeChecker log',
+                'list-flat',
+                {
+                    title: 'runCodeCheckerLog',
+                    command: 'codechecker.executor.runCodeCheckerLog'
+                }
+            ),
+            new OverviewItem(
+                'Preview CodeChecker log in terminal',
+                'terminal',
+                {
+                    title: 'previewLogInTerminal',
+                    command: 'codechecker.executor.previewLogInTerminal'
                 }
             ),
         ]

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -16,9 +16,15 @@ async function main() {
 
         console.error('Tests workspace folder:', STATIC_WORKSPACE_PATH);
 
+        const codeCheckerFolder = path.join(STATIC_WORKSPACE_PATH, '.codechecker');
+
+        if (!await promisify(fs.exists)(codeCheckerFolder)) {
+            await promisify(fs.mkdir)(codeCheckerFolder, { recursive: true });
+        }
+
         // Run CodeChecker on the test workspace first, to get the compile database, and initial files
         const logResult = spawnSync(
-            'CodeChecker log -b "make" -o ./compile_commands.json',
+            'CodeChecker log -b "make" -o ./.codechecker/compile_commands.json',
             { cwd: STATIC_WORKSPACE_PATH, shell: true, stdio: 'inherit' }
         );
 
@@ -31,7 +37,7 @@ async function main() {
         }
 
         const analyzeResult = spawnSync(
-            'CodeChecker analyze ./compile_commands.json -o ./.codechecker/reports',
+            'CodeChecker analyze ./.codechecker/compile_commands.json -o ./.codechecker/reports',
             { cwd: STATIC_WORKSPACE_PATH, shell: true, stdio: 'inherit' }
         );
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,9 +1,33 @@
+import { parse } from 'shell-quote';
 import { workspace } from 'vscode';
 
 export function getConfigAndReplaceVariables(category: string, name: string): string | undefined {
     const configValue = workspace.getConfiguration(category).get<string>(name);
 
     return replaceVariables(configValue);
+}
+
+export function parseShellArgsAndReplaceVariables(shellArgs?: string): string[] {
+    if (!workspace.workspaceFolders) {
+        return [];
+    }
+
+    const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
+
+    const env: { [key: string]: string } = {
+        workspaceFolder,
+        workspaceRoot: workspaceFolder,
+        cwd: process.cwd()
+    };
+    for (const [key, val] of Object.entries(process.env)) {
+        if (val !== undefined) {
+            env[`env:${key}`] = val;
+        }
+    }
+
+    return [ ...parse(shellArgs ?? '', env) ]
+        .filter((entry) => typeof entry === 'string' && entry.length > 0)
+        .map((entry) => replaceVariables(entry as string)!);
 }
 
 export function replaceVariables(pathLike?: string): string | undefined {


### PR DESCRIPTION
Fixes #38.

Instead of running `CodeChecker log` as a separate process, it is now integrated into the `backend/executor.

![image](https://user-images.githubusercontent.com/16914176/165908828-5bfcc968-9d0b-4e98-a35d-b4da06efa423.png)

* Added commands, build tasks, UI buttons for running CodeChecker log.
* Added settings to specify custom args as well as a build command, which can be overridden by commands or tasks.
* Added a couple tests for the backend.