### PR TITLE
Fix handling of removed processes from the execution queue

### DIFF
--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -107,7 +107,7 @@ export class ScheduledProcess implements Disposable {
 
     dispose() {
         if (this.activeProcess) {
-            this.activeProcess.kill();
+            this.killProcess();
         }
 
         this._processStatusChange.fire(ProcessStatus.removed);
@@ -189,6 +189,10 @@ export class ScheduledProcess implements Disposable {
                 this._processStatus = ProcessStatus.running;
                 this._processStatusChange.fire(ProcessStatus.running);
             }
+            break;
+        case ProcessStatus.removed:
+            // dispose() calls killProcess before dispatching this event.
+            this._processStatusChange.fire(ProcessStatus.removed);
             break;
         default:
             if (this._processStatus === ProcessStatus.running) {


### PR DESCRIPTION
Fixes #94.

There were a couple cases where removing the `CodeChecker version` process from the execution queue would never resolve the `checkVersion()` promise.
Since the version check promise wouldn't resolve, the subsequent process is never executed, leading to the UI not updating fully.