### PR TITLE
Refactor report tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,6 +251,60 @@
           "light": "#e07a16",
           "highContrast": "#eeb"
         }
+      },
+      {
+        "id": "severity.critical",
+        "description": "Indicating compilation errors",
+        "defaults": {
+          "dark": "#e92625",
+          "light": "#e92625",
+          "highContrast": "#e92625"
+        }
+      },
+      {
+        "id": "severity.high",
+        "description": "A true positive indicates that the source code will cause a run-time error",
+        "defaults": {
+          "dark": "#ffa800",
+          "light": "#ffa800",
+          "highContrast": "#ffa800"
+        }
+      },
+      {
+        "id": "severity.medium",
+        "description": "A true positive indicates that the source code that may not cause a run-time error (yet), but against intuition and hence prone to error",
+        "defaults": {
+          "dark": "#a9d323",
+          "light": "#a9d323",
+          "highContrast": "#a9d323"
+        }
+      },
+      {
+        "id": "severity.low",
+        "description": "A true positive indicates that the source code is hard to read/understand or could be easily optimized",
+        "defaults": {
+          "dark": "#669603",
+          "light": "#669603",
+          "highContrast": "#669603"
+        }
+      },
+      {
+        "id": "severity.style",
+        "description": "A true positive indicates that the source code is against a specific coding guideline or could improve readability",
+        "defaults": {
+          "dark": "#9932cc",
+          "light": "#9932cc",
+          "highContrast": "#9932cc"
+        }
+      },
+      {
+        "id": "severity.unspecified",
+        "description": "Severity is not specified for a checker",
+        "defaults": {
+          "dark": "#666666",
+          "light": "#666666",
+          "highContrast": "#666666"
+        }
       }
     ]
   },

--- a/src/backend/processor/diagnostics.ts
+++ b/src/backend/processor/diagnostics.ts
@@ -57,6 +57,7 @@ export class DiagnosticsApi {
 
     constructor(ctx: ExtensionContext) {
         ctx.subscriptions.push(this._diagnosticsUpdated = new EventEmitter());
+
         window.onDidChangeVisibleTextEditors(this.onDocumentsChanged, this, ctx.subscriptions);
         ExtensionApi.metadata.metadataUpdated(this.onMetadataUpdated, this, ctx.subscriptions);
 

--- a/src/sidebar/views/reports.ts
+++ b/src/sidebar/views/reports.ts
@@ -1,38 +1,110 @@
-import { basename } from 'path';
+import { basename, relative } from 'path';
 import {
-    Command,
     Event,
     EventEmitter,
     ExtensionContext,
+    ThemeColor,
+    ThemeIcon,
     TreeDataProvider,
     TreeItem,
     TreeItemCollapsibleState,
+    TreeItemLabel,
     TreeView,
+    TreeViewSelectionChangeEvent,
     Uri,
     commands,
-    window
+    window,
+    workspace
 } from 'vscode';
 import { ExtensionApi } from '../../backend/api';
 import { DiagnosticReport } from '../../backend/types';
 
-export interface IssueMetadata {
-    entryIndex?: number | 'sticky';
-    reprStep?: number;
-    reprHasChildren?: boolean;
-    description?: string;
-    command?: Command;
+export class ReportTreeItem extends TreeItem {
+    parent: ReportTreeItem | undefined;
+
+    constructor(
+        public readonly _id: string,
+        public readonly label: string | TreeItemLabel,
+        public readonly iconPath: ThemeIcon,
+        public readonly children?: ReportTreeItem[] | undefined
+    ) {
+        super(label, children?.length ? TreeItemCollapsibleState.Collapsed : TreeItemCollapsibleState.None);
+        this._id = _id;
+        this.label = label;
+        this.iconPath = this.iconPath;
+        this.children = children;
+
+        // Set parent for children automatically.
+        this.children?.forEach(c => c.parent = this);
+    }
+
+    // This function can be used to set ID attribute of a tree item and all the children of it based on the parent id.
+    setId() {
+        this.id = `${this.parent?.id ?? 'root'}_${this._id}`;
+        this.children?.forEach(c => c.setId());
+    }
+
+    // It will expand the tree item (including all the parent items) if the tree item is in collapsed state.
+    expand() {
+        if (this.collapsibleState === TreeItemCollapsibleState.Collapsed) {
+            this.collapsibleState = TreeItemCollapsibleState.Expanded;
+        }
+
+        if (this.parent !== undefined) {
+            this.parent.expand();
+        }
+    }
+
+    traverse(cb: (item: ReportTreeItem) => void) {
+        cb(this);
+        this.children?.forEach(c => c.traverse(cb));
+    }
 }
 
-export class ReportsView implements TreeDataProvider<IssueMetadata> {
+class TreeDiagnosticReport {
+    constructor(
+        public readonly entryId: number,
+        public readonly value: DiagnosticReport
+    ) {
+        this.entryId = entryId;
+        this.value = value;
+    }
+}
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const severityOrder: { [key: string]: number } = {
+    'CRITICAL': 0,
+    'HIGH': 1,
+    'MEDIUM': 2,
+    'LOW': 3,
+    'STYLE': 4,
+    'UNSPECIFIED': 5,
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+export class ReportsView implements TreeDataProvider<ReportTreeItem> {
     protected currentFile?: Uri;
     protected currentEntryList?: DiagnosticReport[];
 
-    protected tree?: TreeView<IssueMetadata>;
+    protected tree?: TreeView<ReportTreeItem>;
+    private treeItems: Map<Uri, ReportTreeItem> = new Map();
+    private selectedTreeItems: ReportTreeItem[] = [];
 
     constructor(ctx: ExtensionContext) {
         ctx.subscriptions.push(this._onDidChangeTreeData = new EventEmitter());
         window.onDidChangeActiveTextEditor(this.refreshBugList, this, ctx.subscriptions);
-        ExtensionApi.diagnostics.diagnosticsUpdated(this.refreshBugList, this, ctx.subscriptions);
+
+        ExtensionApi.diagnostics.diagnosticsUpdated(() => {
+            // FIXME: fired twice when a file is opened freshly.
+            const selected = ExtensionApi.diagnostics.selectedEntry?.position.file;
+            for (const filePath of this.treeItems.keys()) {
+                if (filePath.fsPath !== selected) {
+                    this.treeItems.delete(filePath);
+                }
+            }
+
+            this.refreshBugList();
+        }, this, ctx.subscriptions);
 
         ctx.subscriptions.push(this.tree = window.createTreeView(
             'codechecker.views.reports',
@@ -44,6 +116,10 @@ export class ReportsView implements TreeDataProvider<IssueMetadata> {
 
     protected init() {
         this.currentFile = window.activeTextEditor?.document.uri;
+
+        this.tree?.onDidChangeSelection((item: TreeViewSelectionChangeEvent<ReportTreeItem>) => {
+            this.selectedTreeItems = item.selection;
+        });
     }
 
     private _onDidChangeTreeData: EventEmitter<void>;
@@ -57,6 +133,9 @@ export class ReportsView implements TreeDataProvider<IssueMetadata> {
         commands.executeCommand('setContext', 'codechecker.sidebar.showReports', metadataExists);
 
         const activeUri = window.activeTextEditor?.document.uri;
+        if (!activeUri) {
+            return;
+        }
 
         // Handle Code's Output tab
         if (activeUri?.scheme === 'output') {
@@ -79,252 +158,197 @@ export class ReportsView implements TreeDataProvider<IssueMetadata> {
         this._onDidChangeTreeData.fire();
     }
 
-    getChildren(element?: IssueMetadata): IssueMetadata[] | undefined {
-        // Special case: No file selected
-        if (!this.currentFile) {
-            if (element === undefined) {
-                return [{ description: 'No file selected' }];
+    revealSelectedItems() {
+        const selectedIds = new Set(this.selectedTreeItems.map(item => item.id));
+        this.treeItems.forEach(root => root.traverse(item => {
+            if (selectedIds.has(item.id)) {
+                void this.tree?.reveal(item, { select: true, focus: true });
             }
-
-            return [];
-        }
-
-        // First level, report list
-        if (element?.entryIndex === undefined) {
-            const entryCount = this.currentEntryList?.length ?? 0;
-            const reportsText = entryCount === 1
-                ? '1 report'
-                : `${entryCount === 0 ? 'No' : entryCount} reports`;
-
-            const header: IssueMetadata[] = [
-                { description: `${reportsText} found in file ${basename(this.currentFile!.fsPath)}` }
-            ];
-
-            let selectedHeader: IssueMetadata[] = [];
-
-            if (ExtensionApi.diagnostics.selectedEntry) {
-                selectedHeader = [
-                    {
-                        description: 'Hide active reproduction steps',
-                        command: {
-                            title: 'toggleSteps',
-                            command: 'codechecker.editor.toggleSteps',
-                            arguments: [this.currentFile, -1, false]
-                        }
-                    }
-                ];
-            }
-
-            const stickyHeader: IssueMetadata[] = [
-                { description: '——' },
-                { description: 'Active reproduction steps:' }
-            ];
-
-            const stickyItems: IssueMetadata[] = [];
-
-            // When in the same file as the sticky, displays as part of In current file
-            if (
-                ExtensionApi.diagnostics.selectedEntry &&
-                ExtensionApi.diagnostics.selectedEntry.position.file !== this.currentFile.fsPath) {
-                stickyItems.push({ entryIndex: 'sticky' });
-            }
-
-            const currentHeader: IssueMetadata[] = [
-                { description: '——' },
-                { description: 'In the current file:' }
-            ];
-
-            const currentItems = this.currentEntryList!
-                .map((entry, idx): [DiagnosticReport, number] => [entry, idx])
-                .filter(([entry, _]) => entry.file.original_path === this.currentFile?.fsPath)
-                .map(([_, entryIndex]) => { return { entryIndex }; });
-
-            let sidebar = header.concat(selectedHeader);
-
-            if (stickyItems.length > 0) {
-                sidebar = sidebar.concat(stickyHeader, stickyItems);
-            }
-
-            if (currentItems.length > 0) {
-                sidebar = sidebar.concat(currentHeader, currentItems);
-            }
-
-            return sidebar;
-        }
-
-        // Commands have no children
-        if (element.description !== undefined || element.command !== undefined) {
-            return [];
-        }
-
-        const entry = element.entryIndex === 'sticky'
-            ? ExtensionApi.diagnostics.selectedEntry?.diagnostic
-            : this.currentEntryList![element.entryIndex];
-
-        // No children of sticky when there's no selected report
-        if (entry === undefined) {
-            return [];
-        }
-
-        const path = entry.bug_path_events
-            .map((pathElem, idx) => { return { idx, pathElem }; });
-
-        // Second level, reproduction steps
-        if (element.reprStep === undefined) {
-            const commands: IssueMetadata[] = [];
-
-            // Sticky has a different indexing method
-            if (element.entryIndex === 'sticky') {
-                const { file, idx } = ExtensionApi.diagnostics.selectedEntry!.position;
-
-                commands.push(
-                    {
-                        ...element,
-                        description: 'Jump to report',
-                        command: {
-                            title: 'jumpToReport',
-                            command: 'codechecker.editor.jumpToReport',
-                            arguments: [file, idx, true]
-                        }
-                    },
-                    {
-                        ...element,
-                        description: 'Hide reproduction steps',
-                        command: {
-                            title: 'toggleSteps',
-                            command: 'codechecker.editor.toggleSteps',
-                            arguments: [file, idx]
-                        }
-                    },
-                    { ...element, description: '——' }
-                );
-            } else {
-                const selectedPosition = ExtensionApi.diagnostics.selectedEntry?.position;
-                const isActiveReport = selectedPosition?.idx === element.entryIndex;
-
-                commands.push(
-                    {
-                        ...element,
-                        description: 'Jump to report',
-                        command: {
-                            title: 'jumpToReport',
-                            command: 'codechecker.editor.jumpToReport',
-                            arguments: [this.currentFile, element.entryIndex, true]
-                        }
-                    },
-                    {
-                        ...element,
-                        description: `${isActiveReport ? 'Hide' : 'Show'} reproduction steps`,
-                        command: {
-                            title: 'toggleSteps',
-                            command: 'codechecker.editor.toggleSteps',
-                            arguments: [this.currentFile, element.entryIndex]
-                        }
-                    },
-                    { ...element, description: '——' }
-                );
-            }
-
-            const items = path
-                .map(({ idx }) => {
-                    return {
-                        ...element,
-                        reprStep: idx
-                    };
-                });
-
-            return commands.concat(items);
-        }
-
-        // Third level, no inner-depth children without depth data
-        return [];
+        }));
     }
 
-    getTreeItem(element: IssueMetadata): TreeItem | Thenable<TreeItem> {
-        // Command nodes
-        if (element.command !== undefined) {
-            const item = new TreeItem(element.description ?? element.command.title);
-            item.command = element.command;
+    readonly getTreeItem = (t: ReportTreeItem) => t;
+
+    readonly getParent = (t: ReportTreeItem) => t.parent;
+
+    getReportStepItems({ entryId, value: entry }: TreeDiagnosticReport): ReportTreeItem[] {
+        const selectedPosition = ExtensionApi.diagnostics.selectedEntry?.position;
+        const isActiveReport = selectedPosition?.idx === entryId;
+        const currentFile = this.currentFile;
+
+        const jumpToReportItem = new ReportTreeItem('jumpToReport', 'Jump to report', new ThemeIcon('debug-step-over'));
+        jumpToReportItem.command = {
+            title: 'jumpToReport',
+            command: 'codechecker.editor.jumpToReport',
+            arguments: [currentFile, entryId, true]
+        };
+
+        let toggleStepsItem = null;
+        if (isActiveReport) {
+            toggleStepsItem = new ReportTreeItem(
+                'hideReproductionSteps', 'Hide reproduction steps', new ThemeIcon('eye-closed'));
+        } else {
+            toggleStepsItem = new ReportTreeItem(
+                'showReproductionSteps', 'Show reproduction steps', new ThemeIcon('eye'));
+        }
+
+        toggleStepsItem.command = {
+            title: 'toggleSteps',
+            command: 'codechecker.editor.toggleSteps',
+            arguments: [currentFile, entryId]
+        };
+
+        let indentation = 0;
+        return [
+            jumpToReportItem,
+            toggleStepsItem,
+            ...entry.bug_path_events.map((event, idx) => {
+                const filePath = event.file.original_path;
+                const fileName = basename(filePath);
+
+                const item = new ReportTreeItem(
+                    `${idx + 1}`,
+                    `${'    '.repeat(indentation)} ${idx + 1}. ${fileName}:${event.line} - ${event.message}`,
+                    new ThemeIcon('debug-breakpoint'));
+
+                item.tooltip = [
+                    `Message: ${event.message}`,
+                    `File path: ${filePath}`,
+                    `Line: ${event.line}`,
+                    `Column: ${event.column}`,
+                ].join('\n');
+
+                item.command = {
+                    title: 'jumpToStep',
+                    command: 'codechecker.editor.jumpToStep',
+                    arguments: [currentFile, entryId, idx, true]
+                };
+
+                if (event.message.includes('Calling')) {
+                    indentation += 1;
+                } else if (event.message.includes('Returning from')) {
+                    indentation -= 1;
+                }
+
+                return item;
+            })
+        ];
+    }
+
+    getReportItems(entries: TreeDiagnosticReport[]): ReportTreeItem[] {
+        return entries.map(entry => {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            const {
+                file, line, column, analyzer_name, checker_name, message, report_hash, severity, review_status,
+                bug_path_events
+            } = entry.value;
+            /* eslint-enable @typescript-eslint/naming-convention */
+
+            const item: ReportTreeItem = new ReportTreeItem(
+                `${entry.entryId}`,
+                `L${line} - ${checker_name} [${bug_path_events.length}]`,
+                new ThemeIcon('bug'),
+                this.getReportStepItems(entry));
+
+            item.tooltip = [
+                `Analyze name: ${analyzer_name}`,
+                `Checker name: ${checker_name}`,
+                `Severity: ${severity}`,
+                `File path: ${file.original_path}`,
+                `Line: ${line}`,
+                `Column: ${column}`,
+                `Message: ${message}`,
+                `Report hash: ${report_hash}`,
+                `Review status: ${review_status}`,
+
+            ].join('\n');
+
             return item;
+        });
+    }
+
+    getRootItemThemeIcon(severity: string): ThemeIcon {
+        const color = `severity.${severity.toLocaleLowerCase()}`;
+        return new ThemeIcon('warning', new ThemeColor(color));
+    }
+
+    sortSeverityItems([severityA]: [string, DiagnosticReport[]], [severityB]: [string, DiagnosticReport[]]) {
+        return severityOrder[severityA] - severityOrder[severityB];
+    }
+
+    // Get root level items.
+    getRootItems(): ReportTreeItem[] | undefined {
+        if (!this.currentEntryList?.length) {
+            return [new ReportTreeItem('noReportsFound', 'No reports found', new ThemeIcon('pass'))];
         }
 
-        // Description nodes, also handles special case with no reports
-        if (element.description !== undefined) {
-            return new TreeItem(element.description);
+        const severityItems: { [key: string]: TreeDiagnosticReport[] } = {};
+        for (const [idx, entry] of this.currentEntryList.entries()) {
+            const severity = entry.severity || 'UNSPECIFIED';
+            if (!(severity in severityItems)) {
+                severityItems[severity] = [];
+            }
+            severityItems[severity].push(new TreeDiagnosticReport(idx, entry));
         }
 
-        // Invalid nodes, detect early
-        if (element.entryIndex === undefined) {
-            console.error('Tried to add invalid node to CurrentFileReports tree:', element);
-            return new TreeItem('Internal error - invalid node');
+        const rootItems: ReportTreeItem[] = [];
+
+        rootItems.push(...Object.entries(severityItems)
+            .sort(([severityA]: [string, TreeDiagnosticReport[]], [severityB]: [string, TreeDiagnosticReport[]]) =>
+                severityOrder[severityA] - severityOrder[severityB])
+            .map(([severity, entries]) => {
+                const item: ReportTreeItem = new ReportTreeItem(
+                    severity, severity, this.getRootItemThemeIcon(severity), this.getReportItems(entries));
+
+                return item;
+            }));
+
+        return rootItems;
+    }
+
+    getChildren(t?: ReportTreeItem): ReportTreeItem[] | undefined {
+        const currentFile = this.currentFile;
+        if (!currentFile) {
+            return [new ReportTreeItem('noFileSelected', 'No file selected', new ThemeIcon('warning'))];
         }
 
-        const currentReport = element.entryIndex === 'sticky'
-            ? ExtensionApi.diagnostics.selectedEntry?.diagnostic
-            : this.currentEntryList![element.entryIndex];
-
-        // No children of sticky when there's no selected report
-        if (currentReport === undefined) {
-            return new TreeItem('Loading... - reload metadata if this does not disappear');
+        if (t) {
+            return t.children;
         }
 
-        const isSticky = element.entryIndex === 'sticky' || (
-            this.currentFile?.fsPath === ExtensionApi.diagnostics.selectedEntry?.position.file &&
-            element.entryIndex === ExtensionApi.diagnostics.selectedEntry?.position.idx
-        );
-
-        const steps = currentReport.bug_path_events;
-
-        // First level, report list
-        if (element.reprStep === undefined) {
-            const currentReportPath = currentReport.file.original_path;
-
-            const fileDescription = currentReportPath === this.currentFile?.fsPath
-                ? `[L${currentReport.line}]`
-                : `[${basename(currentReportPath)}:${currentReport.line}]`;
-
-            const item = new TreeItem(`${fileDescription} - ${currentReport.message} [${currentReport.checker_name}]`);
-            item.collapsibleState = isSticky
-                ? TreeItemCollapsibleState.Expanded
-                : TreeItemCollapsibleState.Collapsed;
-            item.description = `(${steps.length})`;
-
-            if (currentReportPath !== this.currentFile?.fsPath) {
-                item.tooltip = `Full path to file: ${currentReportPath}`;
+        if (!this.treeItems.has(currentFile)) {
+            let filePath = currentFile.path;
+            const workspaceFolder = workspace.workspaceFolders?.[0].uri.fsPath;
+            if (workspaceFolder) {
+                filePath = relative(workspaceFolder, filePath);
             }
 
-            return item;
+            const item: ReportTreeItem = new ReportTreeItem(
+                currentFile.path, filePath, new ThemeIcon('file-code'),
+                this.getRootItems());
+            item.setId();
+
+            item.collapsibleState = TreeItemCollapsibleState.Expanded;
+            this.treeItems.set(currentFile, item);
+
+            if (!this.selectedTreeItems.length) {
+                item.children?.[0]?.children?.[0].expand();
+            }
         }
 
-        // Second level, repr steps
-        const currentStep = steps[element.reprStep];
+        this.revealSelectedItems();
 
-        const currentStepFilePath = currentStep.file.original_path;
-        const currentStepFileName = basename(currentStepFilePath);
-
-        const item = new TreeItem(
-            `${element.reprStep + 1}. [${currentStepFileName}:${currentStep.line}] - ${currentStep.message}`
-        );
-        item.tooltip = `Full path to file: ${currentStepFilePath}`;
-        item.collapsibleState = TreeItemCollapsibleState.None;
-
-        // Sticky has a different indexing method
-        if (element.entryIndex === 'sticky') {
-            const { file, idx } = ExtensionApi.diagnostics.selectedEntry!.position;
-
+        const items = [];
+        if (ExtensionApi.diagnostics.selectedEntry) {
+            const item = new ReportTreeItem('hideSteps', 'Hide active reproduction steps', new ThemeIcon('eye-closed'));
             item.command = {
-                title: 'jumpToStep',
-                command: 'codechecker.editor.jumpToStep',
-                arguments: [file, idx, element.reprStep, true]
+                title: 'toggleSteps',
+                command: 'codechecker.editor.toggleSteps',
+                arguments: [this.currentFile, -1, false]
             };
-        } else {
-            item.command = {
-                title: 'jumpToStep',
-                command: 'codechecker.editor.jumpToStep',
-                arguments: [this.currentFile, element.entryIndex, element.reprStep, true]
-            };
+            items.push(item);
         }
 
-        return item;
+        return [...items, ...this.treeItems.values()];
     }
 }


### PR DESCRIPTION
Closes #59, closes #40, supersedes and closes #107.

    Refactor the report tree's code.
    Display depth of report steps.
    Group reports by severity levels.

Fixed my comments in #107.