### PR TITLE
Improvements for handling CodeChecker version checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
           "description": "Enable CodeLens for displaying the reproduction path",
           "default": true
         },
+        "codechecker.executor.enableNotifications": {
+          "type": "boolean",
+          "description": "Enable CodeChecker-related notifications",
+          "default": true
+        },
         "codechecker.executor.runOnSave": {
           "type": "boolean",
           "description": "Controls auto-run of CodeChecker on save",

--- a/src/backend/processor/diagnostics.ts
+++ b/src/backend/processor/diagnostics.ts
@@ -2,6 +2,7 @@ import { Event, EventEmitter, ExtensionContext, TextEditor, Uri, window } from '
 import { parseDiagnostics } from '../parser';
 import { CheckerMetadata, DiagnosticReport } from '../types';
 import { ExtensionApi } from '../api';
+import { shouldShowNotifications } from '../../utils/config';
 
 /**
  * API interface that provides Diagnostics data.
@@ -97,9 +98,12 @@ export class DiagnosticsApi {
         } catch (err: any) {
             console.error('Failed to read CodeChecker data');
             console.error(err);
-            window.showErrorMessage(
-                'Failed to read some CodeChecker diagnostic data\nCheck console for more details'
-            );
+
+            if (shouldShowNotifications()) {
+                window.showErrorMessage(
+                    'Failed to read some CodeChecker diagnostic data\nCheck console for more details'
+                );
+            }
             return;
         }
 

--- a/src/backend/processor/metadata.ts
+++ b/src/backend/processor/metadata.ts
@@ -13,6 +13,7 @@ import {
 import * as path from 'path';
 import { parseMetadata } from '../parser';
 import { CheckerMetadata } from '../types';
+import { shouldShowNotifications } from '../../utils/config';
 
 export class MetadataApi implements Disposable {
     private _metadata?: CheckerMetadata;
@@ -98,7 +99,10 @@ export class MetadataApi implements Disposable {
         this.reloadMetadata()
             .catch((err) => {
                 console.log(err);
-                window.showErrorMessage('Unexpected error when reloading metadata\nCheck console for more details');
+
+                if (shouldShowNotifications()) {
+                    window.showErrorMessage('Unexpected error when reloading metadata\nCheck console for more details');
+                }
             });
     }
 
@@ -113,16 +117,20 @@ export class MetadataApi implements Disposable {
         let precheckFailed = false;
 
         if (!this.metadataPath) {
-            window.showWarningMessage(
-                'Metadata folder has invalid path\n' +
-                'Please change `CodeChecker > Backend > Output folder path` in the settings'
-            );
+            if (shouldShowNotifications()) {
+                window.showWarningMessage(
+                    'Metadata folder has invalid path\n' +
+                    'Please change `CodeChecker > Backend > Output folder path` in the settings'
+                );
+            }
 
             precheckFailed = true;
         }
 
         if (!workspace.workspaceFolders?.length) {
-            window.showInformationMessage('CodeChecker is disabled - open a workspace to get started');
+            if (shouldShowNotifications()) {
+                window.showInformationMessage('CodeChecker is disabled - open a workspace to get started');
+            }
 
             precheckFailed = true;
         }
@@ -147,7 +155,11 @@ export class MetadataApi implements Disposable {
             // For parse errors, print the message instead
             case 'UnsupportedVersion':
                 console.error(err);
-                window.showErrorMessage(`Failed to read CodeChecker metadata: ${err.message}`);
+
+                if (shouldShowNotifications()) {
+                    window.showErrorMessage(`Failed to read CodeChecker metadata: ${err.message}`);
+                }
+
                 break;
 
             default:
@@ -155,12 +167,18 @@ export class MetadataApi implements Disposable {
 
                 // File format errors
                 if (err instanceof SyntaxError) {
-                    window.showErrorMessage('Failed to read CodeChecker metadata: Invalid format');
+                    if (shouldShowNotifications()) {
+                        window.showErrorMessage('Failed to read CodeChecker metadata: Invalid format');
+                    }
+
                     break;
                 }
 
                 // Misc. errors
-                window.showErrorMessage('Failed to read CodeChecker metadata\nCheck console for more details');
+                if (shouldShowNotifications()) {
+                    window.showErrorMessage('Failed to read CodeChecker metadata\nCheck console for more details');
+                }
+
                 break;
             }
         }

--- a/src/editor/executor.ts
+++ b/src/editor/executor.ts
@@ -12,7 +12,7 @@ import {
 import { Editor } from '.';
 import { ExtensionApi } from '../backend';
 import { ProcessStatus } from '../backend/executor/process';
-import { getConfigAndReplaceVariables } from '../utils/config';
+import { getConfigAndReplaceVariables, shouldShowNotifications } from '../utils/config';
 
 export class ExecutorAlerts {
     private statusBarItem: StatusBarItem;
@@ -110,7 +110,10 @@ export class ExecutorAlerts {
             break;
         case ProcessStatus.errored:
             this.statusBarItem.text = '$(testing-error-icon) CodeChecker: analysis errored';
-            window.showErrorMessage('CodeChecker finished with error - see logs for details');
+
+            if (shouldShowNotifications()) {
+                window.showErrorMessage('CodeChecker finished with error - see logs for details');
+            }
             break;
         default:
             break;

--- a/src/editor/initialize.ts
+++ b/src/editor/initialize.ts
@@ -1,5 +1,6 @@
 import { ExtensionContext, commands, window, workspace } from 'vscode';
 import { ExtensionApi } from '../backend';
+import { shouldShowNotifications } from '../utils/config';
 import { Editor } from './editor';
 
 export class FolderInitializer {
@@ -20,6 +21,10 @@ export class FolderInitializer {
     }
 
     async showDialog() {
+        if (!shouldShowNotifications()) {
+            return;
+        }
+
         const workspaceFolder = workspace.workspaceFolders?.length && workspace.workspaceFolders[0].uri;
 
         if (!workspaceFolder) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -43,3 +43,7 @@ export function replaceVariables(pathLike?: string): string | undefined {
         .replace(/\${cwd}/g, process.cwd())
         .replace(/\${env\.([^}]+)}/g, (sub: string, envName: string) => process.env[envName] ?? '');
 }
+
+export function shouldShowNotifications(): boolean {
+    return workspace.getConfiguration('codechecker.executor').get<boolean>('enableNotifications') ?? true;
+}


### PR DESCRIPTION
Fixes #111.

* Refactored the `CodeChecker version` handling, so a version check process couldn't be prematurely killed, leading to a false `CodeChecker not found` notification. (Should be enough to fix the particular issue showing double notifs.)
* Added a toggle to disable version-check related notifications altogether