### PR TITLE
Initial multi-root support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Since CodeChecker-related paths vary greatly between systems, the following sett
 | Name | Description |
 | --- | --- |
 | CodeChecker > Backend > Output folder <br> (default: `${workspaceFolder}/.codechecker`) | The output folder where the CodeChecker analysis files are stored. |
-| CodeChecker > Backend > Compilation database path <br> (default: *(empty)*) | Path to a custom compilation database, in case of a custom build system. The database setup dialog sets the path for the current workspace only. |
+| CodeChecker > Backend > Compilation database path <br> (default: *(empty)*) | Path to a custom compilation database, in case of a custom build system. The database setup dialog sets the path for the current workspace only. Leave blank to use the database in CodeChecker's output folder, or to use CodeChecker's autodetection for multi-root workspaces. |
 | CodeChecker > Editor > Show database dialog <br> (default: `on`) | Controls the dialog when opening a workspace without a compilation database. |
 | CodeChecker > Editor > Enable CodeLens <br> (default: `on`) | Enable CodeLens for displaying the reproduction path in the editor. |
 | CodeChecker > Executor > Enable notifications <br> (default: `on`) | Enable CodeChecker-related toast notifications. |

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         },
         "codechecker.backend.compilationDatabasePath": {
           "type": "string",
-          "description": "Path to a custom compilation database, in case of a custom build system",
+          "description": "Path to a custom compilation database, in case of a custom build system. Leave blank to use the database in CodeChecker's output folder, or to use CodeChecker's autodetection for multi-root workspaces.",
           "default": null,
           "order": 3
         },

--- a/src/editor/notifications.ts
+++ b/src/editor/notifications.ts
@@ -57,7 +57,7 @@ export class NotificationHandler {
                 break;
             }
 
-            const choiceCommand = options.choices!.find((command) => command.title === choice);
+            const choiceCommand = options.choices?.find((command) => command.title === choice);
             if (choiceCommand !== undefined && choiceCommand.command !== '') {
                 await commands.executeCommand(choiceCommand.command, ...(choiceCommand.arguments ?? []));
             }

--- a/src/sidebar/views/overview.ts
+++ b/src/sidebar/views/overview.ts
@@ -80,93 +80,68 @@ export class OverviewView implements TreeDataProvider<OverviewItem> {
         ]
     };
 
-    private bottomItems: {[id: string]: OverviewItem[]} = {
-        'normal': [
-            new OverviewItem(
-                'Reload CodeChecker metadata',
-                'debug-restart',
-                {
-                    title: 'reloadMetadata',
-                    command: 'codechecker.backend.reloadMetadata',
-                }
-            ),
-            new OverviewItem(
-                'Re-analyze current file',
-                'run',
-                {
-                    title: 'reloadMetadata',
-                    command: 'codechecker.executor.analyzeCurrentFile',
-                },
-            ),
-            new OverviewItem(
-                'Re-analyze entire project',
-                'run-all',
-                {
-                    title: 'reloadMetadata',
-                    command: 'codechecker.executor.analyzeProject',
-                }
-            ),
-            new OverviewItem(
-                'Re-run CodeChecker log',
-                'list-flat',
-                {
-                    title: 'runCodeCheckerLog',
-                    command: 'codechecker.executor.runCodeCheckerLog'
-                }
-            ),
-            new OverviewItem(
-                'Preview CodeChecker log in terminal',
-                'terminal',
-                {
-                    title: 'previewLogInTerminal',
-                    command: 'codechecker.executor.previewLogInTerminal'
-                }
-            ),
-            new OverviewItem(
-                'Stop analysis',
-                'debug-stop',
-                {
-                    title: 'stopAnalysis',
-                    command: 'codechecker.executor.stopAnalysis',
-                }
-            ),
-        ],
-        'ccNotFound': [
-            new OverviewItem(
-                'Setup compilation database',
-                'database',
-                {
-                    title: 'showSetupDialog',
-                    command: 'codechecker.editor.showSetupDialog'
-                }
-            ),
-            new OverviewItem('——'),
-            new OverviewItem(
-                'Reload CodeChecker metadata',
-                'debug-restart',
-                {
-                    title: 'reloadMetadata',
-                    command: 'codechecker.backend.reloadMetadata',
-                }
-            ),
-            new OverviewItem(
-                'Run CodeChecker log',
-                'list-flat',
-                {
-                    title: 'runCodeCheckerLog',
-                    command: 'codechecker.executor.runCodeCheckerLog'
-                }
-            ),
-            new OverviewItem(
-                'Preview CodeChecker log in terminal',
-                'terminal',
-                {
-                    title: 'previewLogInTerminal',
-                    command: 'codechecker.executor.previewLogInTerminal'
-                }
-            ),
-        ]
-    };
+    private bottomItems = [
+        new OverviewItem(
+            'Reload CodeChecker metadata',
+            'debug-restart',
+            {
+                title: 'reloadMetadata',
+                command: 'codechecker.backend.reloadMetadata',
+            }
+        ),
+        new OverviewItem(
+            'Re-analyze current file',
+            'run',
+            {
+                title: 'reloadMetadata',
+                command: 'codechecker.executor.analyzeCurrentFile',
+            },
+        ),
+        new OverviewItem(
+            'Re-analyze entire project',
+            'run-all',
+            {
+                title: 'reloadMetadata',
+                command: 'codechecker.executor.analyzeProject',
+            }
+        ),
+        new OverviewItem(
+            'Re-run CodeChecker log',
+            'list-flat',
+            {
+                title: 'runCodeCheckerLog',
+                command: 'codechecker.executor.runCodeCheckerLog'
+            }
+        ),
+        new OverviewItem(
+            'Preview CodeChecker log in terminal',
+            'terminal',
+            {
+                title: 'previewLogInTerminal',
+                command: 'codechecker.executor.previewLogInTerminal'
+            }
+        ),
+        new OverviewItem(
+            'Stop analysis',
+            'debug-stop',
+            {
+                title: 'stopAnalysis',
+                command: 'codechecker.executor.stopAnalysis',
+            }
+        ),
+    ];
+
+    private ccNotFoundItems = [
+        new OverviewItem('——'),
+        new OverviewItem(
+            'Setup compilation database',
+            'database',
+            {
+                title: 'showSetupDialog',
+                command: 'codechecker.editor.showSetupDialog'
+            }
+        ),
+    ];
 
     private separator = [new OverviewItem('——')];
 
@@ -200,11 +175,11 @@ export class OverviewView implements TreeDataProvider<OverviewItem> {
             ? this.topItems.normal
             : this.topItems.notFound;
 
-        const bottomItems = ExtensionApi.executorBridge.getCompileCommandsPath() !== undefined
-            ? this.bottomItems.normal
-            : this.bottomItems.ccNotFound;
+        const ccNotFoundItems = ExtensionApi.executorBridge.getCompileCommandsPath() === undefined
+            ? this.ccNotFoundItems
+            : [];
 
-        this.itemsList = [topItems, this.separator, bottomItems];
+        this.itemsList = [topItems, this.separator, this.bottomItems, ccNotFoundItems];
 
         this._onDidChangeTreeData.fire();
     }

--- a/src/test/executor/executor.functional.test.ts
+++ b/src/test/executor/executor.functional.test.ts
@@ -105,7 +105,7 @@ suite('Functional Test: Backend - Executor', () => {
         await assert.doesNotReject(() => statusWatch, 'CodeChecker log errored');
 
         // Wait for file watcher events to register
-        await new Promise((res) => setTimeout(res, 100));
+        await new Promise((res) => setTimeout(res, 500));
 
         assert.ok(logSpy.called, 'log command starter not called');
 
@@ -132,7 +132,7 @@ suite('Functional Test: Backend - Executor', () => {
         await assert.doesNotReject(() => statusWatch, 'CodeChecker log errored');
 
         // Wait for file watcher events to register
-        await new Promise((res) => setTimeout(res, 100));
+        await new Promise((res) => setTimeout(res, 500));
 
         assert.ok(logSpy.called, 'log command starter not called');
 
@@ -162,7 +162,7 @@ suite('Functional Test: Backend - Executor', () => {
         await assert.doesNotReject(() => statusWatch, 'CodeChecker analyze errored');
 
         // Wait for file watcher events to register
-        await new Promise((res) => setTimeout(res, 100));
+        await new Promise((res) => setTimeout(res, 500));
 
         assert.ok(analyzeSpy.called, 'analyze file starter not called');
 
@@ -188,7 +188,7 @@ suite('Functional Test: Backend - Executor', () => {
         await assert.doesNotReject(() => statusWatch, 'CodeChecker analyze errored');
 
         // Wait for file watcher events to register
-        await new Promise((res) => setTimeout(res, 100));
+        await new Promise((res) => setTimeout(res, 500));
 
         assert.ok(isFileChanged, 'CodeChecker analysis did not set metadata on project');
     }).timeout(5000);

--- a/src/test/executor/executor.functional.test.ts
+++ b/src/test/executor/executor.functional.test.ts
@@ -64,7 +64,7 @@ suite('Functional Test: Backend - Executor', () => {
 
     test('CodeChecker version check out of the box', async function() {
         // If version is already checked, set to false to force a new check
-        executorBridge['versionChecked'] = false;
+        executorBridge['checkedVersion'] = false;
 
         const versionSpy = sinon.spy(executorBridge, 'checkVersion');
         const statusWatch = processStatusChange();
@@ -77,7 +77,7 @@ suite('Functional Test: Backend - Executor', () => {
 
         const isVersionChecked = await versionSpy.returnValues[0];
         assert.ok(
-            isVersionChecked && executorBridge['versionChecked'],
+            isVersionChecked && executorBridge['checkedVersion'],
             'does not work with clean CodeChecker out of the box'
         );
 


### PR DESCRIPTION
Requires #123. Reference: #113, Ericsson/CodeChecker#3708

Adds support for CodeChecker 6.22's automatic compilation database detection. If no comp.db. is specified, and there is none in CodeChecker's output folder, the extension will use CodeChecker's autodetection (for 6.22 and above). For 6.21, and the mentioned cases, the behavior remains the same.

Remaining tasks:
- Design and implement commands for building multi-root projects. Currently you can only build either a single file, or the outermost folder via the default commands.
- Support for anayzing 2 or more files without an explicit comp.db. From my reading, `CodeChecker analyze` can only accept a single file or folder as input, so for multiple files we'd need to autodetect common folders, or run the analysis for each file separately.
- Handle failure of `CodeChecker analyze` if it does not detect a compilation database. Currently it returns code 0, so we'd need to read its output to detect the failure.