### PR TITLE
Fix vsce rewriting and refactor tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,12 +6,26 @@ on:
     types: [published]
 
 jobs:
+  version:
+    name: Version dummy
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/}
+
   test:
     uses: ./.github/workflows/test.yml
+  package:
+    needs: [version]
+    uses: ./.github/workflows/package.yml
+    with:
+      version: ${{ needs.version.output.version }}
+
   build:
     name: Create extension
     runs-on: ubuntu-22.04
-    needs: [test]
+    needs: [test, package, version]
 
     # Each registry should have the following fields:
     #   - name: unique extension id.
@@ -31,38 +45,10 @@ jobs:
             token: VS_MARKETPLACE_TOKEN
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16.x
-
-      - name: Enable Yarn 2
-        run: yarn set version stable
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-
-      - name: Create vsix package
-        if: success()
-        id: build
-        run: |
-          sed -i 's/"name": "codechecker"/"name": "${{ matrix.name }}"/' package.json
-          yarn run vsce package --no-git-tag-version --yarn ${{ steps.get_version.outputs.VERSION }}
-          echo ::set-output name=vsixPath::$(readlink -f *.vsix)
-
-      - name: Create vsix artifact
-        if: success()
-        uses: actions/upload-artifact@master
+      - name: Get vsix artifact
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.registry }}-package
-          path: ${{ steps.build.outputs.vsixPath }}
 
       - name: Publish package
         if: success()
@@ -70,4 +56,4 @@ jobs:
         with:
           pat: ${{ secrets[matrix.token] }}
           registryUrl: ${{ matrix.registryUrl }}
-          extensionFile: ${{ steps.build.outputs.vsixPath }}
+          extensionFile: ./${{ matrix.name }}-${{ needs.version.output.version }}.vsix

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   version:
-    name: Version dummy
+    name: Get version number
     runs-on: ubuntu-22.04
     steps:
       - name: Get the version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/}
+        run: echo version=${GITHUB_REF#refs/tags/} >>$GITHUB_OUTPUT
 
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,5 @@
 name: Package CodeChecker VSCode extension
 
-# Triggers the workflow on push or pull request events.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,7 +39,7 @@ jobs:
           sed -i 's/"name": "codechecker"/"name": "${{ matrix.name }}"/' package.json
           sed -i 's/codechecker@workspace/${{ matrix.name }}@workspace/' yarn.lock
           yarn run vsce package --no-git-tag-version --yarn ${{ inputs.version }}
-          echo ::set-output name=vsixPath::$(readlink -f *.vsix)
+          echo vsixPath=$(readlink -f *.vsix) >>$GITHUB_OUTPUT
 
       - name: Create vsix artifact
         if: success()

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,49 @@
+name: Package CodeChecker VSCode extension
+
+# Triggers the workflow on push or pull request events.
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+jobs:
+  package:
+    name: Create extension package
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        registry: [open-vsx, vs-marketplace]
+        include:
+          - registry: open-vsx
+            name: codechecker
+          - registry: vs-marketplace
+            name: vscode-codechecker
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Enable Yarn 2
+        run: yarn set version stable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+        
+      # Should be kept in sync with `deploy.yml`.
+      - name: Create vsix package
+        if: success()
+        id: build
+        run: |
+          sed -i 's/"name": "codechecker"/"name": "${{ matrix.name }}"/' package.json
+          sed -i 's/codechecker@workspace/${{ matrix.name }}@workspace/' yarn.lock
+          yarn run vsce package --no-git-tag-version --yarn ${{ inputs.version }}
+          echo ::set-output name=vsixPath::$(readlink -f *.vsix)
+
+      - name: Create vsix artifact
+        if: success()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ matrix.registry }}-package
+          path: ${{ steps.build.outputs.vsixPath }}

--- a/.github/workflows/test-commit.yml
+++ b/.github/workflows/test-commit.yml
@@ -1,0 +1,31 @@
+name: codechecker-vscodeplugin-tests
+
+# Triggers the workflow on push or pull request events.
+on: [push, pull_request]
+
+jobs:
+  version:
+    name: Get version number
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo version=0.0.0-$(echo ${GITHUB_SHA} | head -c 7) >>$GITHUB_OUTPUT
+
+  package:
+    needs: [version]
+    uses: ./.github/workflows/package.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+
+  test:
+    uses: ./.github/workflows/test.yml
+
+  # Needed to run the packaging and tests in parallel
+  test-commit:
+    name: Run commit tests
+    needs: [package, test]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Do nothing
+        run: ":"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,21 +4,41 @@ name: codechecker-vscodeplugin-tests
 on: [push, pull_request, workflow_call]
 
 jobs:
+  version:
+    name: Version dummy
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=version::0.0.0-$(echo ${GITHUB_SHA} | head -c 7)
+
+  package:
+    needs: [version]
+    uses: ./.github/workflows/package.yml
+    with:
+      version: ${{ needs.version.outputs.version }}
+
   test:
     name: Tests
     runs-on: ubuntu-22.04
+    needs: [package]
+
     steps:
       - uses: actions/checkout@v3
+
       - name: Enable Yarn 2
         run: yarn set version stable
+
       - name: Install dependencies
         run: yarn install --immutable
+
       - name: Install CodeChecker
         run: |
           sudo apt install -y clang-tidy
           sudo snap install codechecker --classic
           sudo snap alias codechecker CodeChecker
           CodeChecker version
+
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1.6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,27 +1,11 @@
-name: codechecker-vscodeplugin-tests
+name: Run plugin tests
 
-# Triggers the workflow on push or pull request events.
-on: [push, pull_request, workflow_call]
+on: [workflow_call]
 
 jobs:
-  version:
-    name: Version dummy
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Get the version
-        id: get_version
-        run: echo version=0.0.0-$(echo ${GITHUB_SHA} | head -c 7) >>$GITHUB_OUTPUT
-
-  package:
-    needs: [version]
-    uses: ./.github/workflows/package.yml
-    with:
-      version: ${{ needs.version.outputs.version }}
-
   test:
     name: Tests
     runs-on: ubuntu-22.04
-    needs: [package]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::0.0.0-$(echo ${GITHUB_SHA} | head -c 7)
+        run: echo version=0.0.0-$(echo ${GITHUB_SHA} | head -c 7) >>$GITHUB_OUTPUT
 
   package:
     needs: [version]


### PR DESCRIPTION
The rewriter for publishing to the Marketplace also needs to rewrite a couple things within `yarn.lock`.

Updated the GH Actions files to use the new output syntax, and refactored tests - they now also test `vsce package` on the plugin.