### PR TITLE
Add setting to change how severities are displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Since CodeChecker-related paths vary greatly between systems, the following sett
 | --- | --- |
 | CodeChecker > Backend > Output folder <br> (default: `${workspaceFolder}/.codechecker`) | The output folder where the CodeChecker analysis files are stored. |
 | CodeChecker > Backend > Compilation database path <br> (default: *(empty)*) | Path to a custom compilation database, in case of a custom build system. The database setup dialog sets the path for the current workspace only. Leave blank to use the database in CodeChecker's output folder, or to use CodeChecker's autodetection for multi-root workspaces. |
+| CodeChecker > Editor > Custom bug severities <br> (default: `null`) | Control how a bug is displayed in the editor, depending on what its severity is. Bugs can be displayed as 'Error', 'Warning', 'Information' or 'Hint'. By default, everything except 'STYLE' severity is displayed as an error. Configured as an array, such as `{ "UNSPECIFIED": "Warning", "LOW": "Warning" }` |
 | CodeChecker > Editor > Show database dialog <br> (default: `on`) | Controls the dialog when opening a workspace without a compilation database. |
 | CodeChecker > Editor > Enable CodeLens <br> (default: `on`) | Enable CodeLens for displaying the reproduction path in the editor. |
 | CodeChecker > Executor > Enable notifications <br> (default: `on`) | Enable CodeChecker-related toast notifications. |

--- a/package.json
+++ b/package.json
@@ -158,6 +158,14 @@
           "description": "Enable CodeLens for displaying the reproduction path",
           "default": true
         },
+        "codechecker.editor.customBugSeverities": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "Control how a bug is displayed in the editor, depending on what its severity is. Bugs can be displayed as 'Error', 'Warning', 'Information' or 'Hint'. By default, everything except 'STYLE' severity is displayed as an error.",
+          "default": null
+        },
         "codechecker.executor.enableNotifications": {
           "type": "boolean",
           "description": "Enable pop-up notifications. Past messages are accessible via the sidebar menu regardless of this setting.",

--- a/package.json
+++ b/package.json
@@ -159,12 +159,24 @@
           "default": true
         },
         "codechecker.editor.customBugSeverities": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "description": "Control how a bug is displayed in the editor, depending on what its severity is. Bugs can be displayed as 'Error', 'Warning', 'Information' or 'Hint'. By default, everything except 'STYLE' severity is displayed as an error.",
-          "default": null
+          "type": "object",
+          "description": "Control how a bug is displayed in the editor, depending on what its severity is.",
+          "additionalProperties": {
+            "type": "string",
+            "enum": [
+              "Error",
+              "Warning",
+              "Information",
+              "Hint"
+            ]
+          },
+          "default": {
+            "HIGH": "Error",
+            "MEDIUM": "Error",
+            "LOW": "Error",
+            "UNSPECIFIED": "Error",
+            "STYLE": "Warning"
+          }
         },
         "codechecker.executor.enableNotifications": {
           "type": "boolean",


### PR DESCRIPTION
Fixes #139. Requires #140 for CI passing.

By default, all CodeChecker bug severities except STYLE are displayed as errors inside the editor. This PR adds a setting to enable changing how each of these severities are displayed.