### PR TITLE
Fix `codechecker.executor.showOutput` command

### DIFF
--- a/src/editor/executor.ts
+++ b/src/editor/executor.ts
@@ -36,7 +36,7 @@ export class ExecutorAlerts {
 
     init() {
         this.statusBarItem.text = 'CodeChecker: not running';
-        this.statusBarItem.command = { title: '', command: 'codechecker.logging.showOutput' };
+        this.statusBarItem.command = { title: '', command: 'codechecker.executor.showOutput' };
         this.statusBarItem.show();
     }
 

--- a/src/editor/logger.ts
+++ b/src/editor/logger.ts
@@ -8,7 +8,7 @@ export class LoggerPanel {
         ctx.subscriptions.push(this.window = window.createOutputChannel('CodeChecker'));
 
         ctx.subscriptions.push(
-            commands.registerCommand('codechecker.logging.showOutput', this.showOutputTab, this)
+            commands.registerCommand('codechecker.executor.showOutput', this.showOutputTab, this)
         );
 
         ExtensionApi.executorBridge.bridgeMessages(this.window.append, this.window, ctx.subscriptions);


### PR DESCRIPTION
Requires https://github.com/Ericsson/CodecheckerVSCodePlugin/pull/140 for CI passing.

In some locations, the commands `codechecker.logging.showOutput` and `codechecker.executor.showOutput` were inconsistently used. They are now all `codechecker.executor.showOutput`.
Fixes sidebar commands when CodeChecker is running, among others.