### PR TITLE
Add support for CodeChecker warning/error reasons

### DIFF
--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -17,7 +17,7 @@ import {
     parseShellArgsAndReplaceVariables,
     replaceVariables
 } from '../../utils/config';
-import { ProcessStatus, ProcessType, ScheduledProcess } from '.';
+import { ProcessStatusType, ProcessType, ScheduledProcess } from '.';
 import { NotificationType } from '../../editor/notifications';
 import { Editor } from '../../editor';
 
@@ -461,7 +461,7 @@ export class ExecutorBridge implements Disposable {
         process.processStdout((output) => processOutput += output);
 
         process.processStatusChange((status) => {
-            if (status === ProcessStatus.finished) {
+            if (status.type === ProcessStatusType.finished) {
                 ExtensionApi.metadata.parseCheckerData(processOutput);
             }
         });
@@ -504,7 +504,7 @@ export class ExecutorBridge implements Disposable {
         process.processStdout((output) => processOutput += output);
 
         process.processStatusChange((status) => {
-            if (status === ProcessStatus.finished) {
+            if (status.type === ProcessStatusType.finished) {
                 ExtensionApi.diagnostics.parseDiagnosticsData(processOutput);
             }
         });
@@ -558,9 +558,9 @@ export class ExecutorBridge implements Disposable {
             process.processStdout((output) => processOutput += output);
 
             process.processStatusChange(async (status) => {
-                switch (status) {
-                case ProcessStatus.running: return;
-                case ProcessStatus.finished:
+                switch (status.type) {
+                case ProcessStatusType.running: return;
+                case ProcessStatusType.finished:
                     try {
                         const data = JSON.parse(processOutput) as AnalyzerVersion;
 
@@ -651,7 +651,7 @@ export class ExecutorBridge implements Disposable {
                     }
 
                     break;
-                case ProcessStatus.removed:
+                case ProcessStatusType.removed:
                     if (this.checkedVersion === undefined) {
                         this.checkedVersion = false;
                     }

--- a/src/backend/executor/process.ts
+++ b/src/backend/executor/process.ts
@@ -114,13 +114,14 @@ export class ScheduledProcess implements Disposable {
             this.processParameters.forwardStdoutToLogs = !forwardDefaults.includes(processType);
         }
 
-        const parseLogMessage = (line: string) => {
-            // Do not store json output as last error
-            if (line.startsWith('{') || line === '') {
-                return;
-            }
+        const parseLogMessage = (stdout: string) => {
+            // Do not store json output or meta messages as last error
+            const lines = stdout.split('\n')
+                .filter((line) => !line.startsWith('{') && !line.startsWith('>') && line !== '');
 
-            this.lastLogMessage = line;
+            if (lines.length > 0) {
+                this.lastLogMessage = lines[lines.length - 1];
+            }
         };
 
         this.processStdout(parseLogMessage, this);

--- a/src/editor/executor.ts
+++ b/src/editor/executor.ts
@@ -11,7 +11,7 @@ import {
 } from 'vscode';
 import { Editor } from '.';
 import { ExtensionApi } from '../backend';
-import { ProcessStatus, ScheduledProcess } from '../backend/executor/process';
+import { ProcessStatus, ProcessStatusType, ScheduledProcess } from '../backend/executor/process';
 import { getConfigAndReplaceVariables } from '../utils/config';
 import { NotificationType } from './notifications';
 
@@ -93,23 +93,23 @@ export class ExecutorAlerts {
             return;
         }
 
-        if (status === ProcessStatus.running) {
+        if (status.type === ProcessStatusType.running) {
             this.statusBarItem.text = '$(loading) CodeChecker: analysis in progress...';
             this.statusBarItem.show();
             return;
         }
 
-        switch (status) {
-        case ProcessStatus.finished:
+        switch (status.type) {
+        case ProcessStatusType.finished:
             this.statusBarItem.text = '$(testing-passed-icon) CodeChecker: analysis finished';
             break;
-        case ProcessStatus.killed:
+        case ProcessStatusType.killed:
             this.statusBarItem.text = '$(testing-failed-icon) CodeChecker: analysis killed';
             break;
-        case ProcessStatus.notRunning:
+        case ProcessStatusType.notRunning:
             this.statusBarItem.text = '$(info) CodeChecker: ready';
             break;
-        case ProcessStatus.errored:
+        case ProcessStatusType.errored:
             this.statusBarItem.text = '$(testing-error-icon) CodeChecker: analysis errored';
 
             Editor.notificationHandler.showNotification(

--- a/src/editor/executor.ts
+++ b/src/editor/executor.ts
@@ -112,9 +112,11 @@ export class ExecutorAlerts {
         case ProcessStatusType.errored:
             this.statusBarItem.text = '$(testing-error-icon) CodeChecker: analysis errored';
 
+            const logLocation = status.reason ? 'sidebar' : 'output log';
+
             Editor.notificationHandler.showNotification(
                 NotificationType.error,
-                'CodeChecker finished with error - see logs for details'
+                `CodeChecker finished with error - see the ${logLocation} for details`
             );
             break;
         default:

--- a/src/editor/notifications.ts
+++ b/src/editor/notifications.ts
@@ -99,6 +99,22 @@ export class NotificationHandler {
             };
         };
 
+        const makeReason = (): (Command)[] => {
+            if (!status.reason) {
+                return [];
+            }
+
+            return [{
+                title: `Reason: ${status.reason}`,
+                command: 'codechecker.executor.showOutput',
+                tooltip: `Reason: ${status.reason}\nSee the output log for full details`
+            },
+            {
+                title: 'Show process logs',
+                command: 'codechecker.executor.showOutput'
+            }];
+        };
+
         switch (status.type) {
         case ProcessStatusType.queued: {
             const newNotification = SidebarContainer.notificationView.addNotification(
@@ -148,7 +164,16 @@ export class NotificationHandler {
         case ProcessStatusType.finished: {
             notification!.update({
                 message: makeMessage('finished running'),
-                choices: []
+                choices: makeReason()
+            });
+            this.activeNotifications.delete(process.commandLine);
+
+            break;
+        }
+        case ProcessStatusType.warning: {
+            notification!.update({
+                message: makeMessage('finished with warnings'),
+                choices: makeReason()
             });
             this.activeNotifications.delete(process.commandLine);
 
@@ -157,10 +182,7 @@ export class NotificationHandler {
         case ProcessStatusType.errored: {
             notification!.update({
                 message: makeMessage('finished with errors'),
-                choices: [{
-                    title: 'Show process logs',
-                    command: 'codechecker.executor.showOutput'
-                }]
+                choices: makeReason()
             });
             this.activeNotifications.delete(process.commandLine);
 

--- a/src/editor/notifications.ts
+++ b/src/editor/notifications.ts
@@ -1,6 +1,6 @@
 import { Command, ConfigurationChangeEvent, ExtensionContext, commands, window, workspace } from 'vscode';
 import { ExtensionApi } from '../backend';
-import { ProcessStatus, ProcessType, ScheduledProcess } from '../backend/executor';
+import { ProcessStatus, ProcessStatusType, ProcessType, ScheduledProcess } from '../backend/executor';
 import { SidebarContainer } from '../sidebar';
 import { NotificationItem } from '../sidebar/views';
 
@@ -87,7 +87,7 @@ export class NotificationHandler {
         }
 
         const notification = this.activeNotifications.get(process.commandLine);
-        if (notification === undefined && status !== ProcessStatus.queued) {
+        if (notification === undefined && status.type !== ProcessStatusType.queued) {
             return;
         }
 
@@ -99,8 +99,8 @@ export class NotificationHandler {
             };
         };
 
-        switch (status) {
-        case ProcessStatus.queued: {
+        switch (status.type) {
+        case ProcessStatusType.queued: {
             const newNotification = SidebarContainer.notificationView.addNotification(
                 'browser', makeMessage('added to the process queue'), [
                     {
@@ -118,7 +118,7 @@ export class NotificationHandler {
 
             break;
         }
-        case ProcessStatus.running: {
+        case ProcessStatusType.running: {
             notification!.silentUpdate({ choices: [] });
 
             const newNotification = SidebarContainer.notificationView.addNotification(
@@ -136,7 +136,7 @@ export class NotificationHandler {
 
             break;
         }
-        case ProcessStatus.killed: {
+        case ProcessStatusType.killed: {
             notification!.update({
                 message: makeMessage('was killed'),
                 choices: []
@@ -145,7 +145,7 @@ export class NotificationHandler {
 
             break;
         }
-        case ProcessStatus.finished: {
+        case ProcessStatusType.finished: {
             notification!.update({
                 message: makeMessage('finished running'),
                 choices: []
@@ -154,7 +154,7 @@ export class NotificationHandler {
 
             break;
         }
-        case ProcessStatus.errored: {
+        case ProcessStatusType.errored: {
             notification!.update({
                 message: makeMessage('finished with errors'),
                 choices: [{
@@ -166,7 +166,7 @@ export class NotificationHandler {
 
             break;
         }
-        case ProcessStatus.removed: {
+        case ProcessStatusType.removed: {
             notification!.update({
                 message: makeMessage('removed from the process queue'),
                 type: 'browser',

--- a/src/test/executor/executor.functional.test.ts
+++ b/src/test/executor/executor.functional.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 const sinon = require('sinon');
 import { ConfigurationTarget, Uri, commands, extensions, workspace } from 'vscode';
-import { ExecutorBridge, ExecutorManager, ProcessStatus, ProcessType } from '../../backend/executor';
+import { ExecutorBridge, ExecutorManager, ProcessStatusType, ProcessType } from '../../backend/executor';
 import { CodeCheckerExtension } from '../../extension';
 import { STATIC_WORKSPACE_PATH } from '../utils/constants';
 import { closeAllTabs, openDocument } from '../utils/files';
@@ -17,13 +17,14 @@ suite('Functional Test: Backend - Executor', () => {
 
     const processStatusChange = async () => new Promise<void>((res, rej) => {
         const disposable = executorManager.processStatusChange(([status, _]) => {
-            switch (status) {
-            case ProcessStatus.finished:
+            switch (status.type) {
+            case ProcessStatusType.finished:
+            case ProcessStatusType.warning:
                 disposable.dispose();
                 res();
                 return;
-            case ProcessStatus.errored:
-            case ProcessStatus.killed:
+            case ProcessStatusType.errored:
+            case ProcessStatusType.killed:
                 disposable.dispose();
                 rej('process not exited cleanly');
                 return;


### PR DESCRIPTION
Fixes (partially) #137 

CodeChecker is assumed to output a summary of its analysis in a user-readable manner, on its last stderr line.

This reason is now displayed on the sidebar, if available.
Also added support for differentiating between CodeChecker warnings/errors.

![image](https://github.com/Ericsson/CodecheckerVSCodePlugin/assets/16914176/e27a59f3-1af4-4b42-98f5-6635b3c79bad)

(The full reason is of course shown on hover.)