### PR TITLE
Add analysis timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Since CodeChecker-related paths vary greatly between systems, the following sett
 | CodeChecker > Editor > Enable CodeLens <br> (default: `on`) | Enable CodeLens for displaying the reproduction path in the editor. |
 | CodeChecker > Executor > Enable notifications <br> (default: `on`) | Enable CodeChecker-related toast notifications. |
 | CodeChecker > Executor > Executable path <br> (default: `CodeChecker`) | Path to the CodeChecker executable. Can be an executable in the `PATH` environment variable, or an absolute path to one. |
+| CodeChecker > Executor > Analysis timeout <br> (default: *60*) | The timeout (in seconds) for each individual analysis run by the CodeChecker analyze command - set to 0 to disable the timeout. |
 | CodeChecker > Executor > Thread count <br> (default: *(empty)*) | CodeChecker's thread count - leave empty to use all threads. |
 | CodeChecker > Executor > Arguments <br> (default: *(empty)*) | Additional arguments to `CodeChecker analyze`. For example, if you want to use a config file for CodeChecker pass '--config <config.json>'. For supported arguments, run `CodeChecker analyze --help`. <br> *Note:* The resulting command-line can be previewed with the command `CodeChecker: Show full CodeChecker analyze command line`. |
 | CodeChecker > Executor > Log build command <br> (default: `make`) | The default build command used when running `CodeChecker log` via commands or tasks. |

--- a/package.json
+++ b/package.json
@@ -149,6 +149,12 @@
           "minimum": 1,
           "order": 5
         },
+        "codechecker.executor.analysisTimeout": {
+          "type": "number",
+          "description": "The timeout (in seconds) for each individual analysis run by the CodeChecker analyze command - set to 0 to disable the timeout",
+          "default": 60,
+          "order": 6
+        },
         "codechecker.executor.logBuildCommand": {
           "type": "string",
           "description": "The build command passed to CodeChecker log.",
@@ -158,7 +164,7 @@
           "type": "string",
           "description": "The build command passed to CodeChecker log.",
           "default": "make",
-          "order": 6
+          "order": 7
         },
         "codechecker.executor.logArguments": {
           "type": "string",
@@ -169,7 +175,7 @@
           "type": "string",
           "description": "Additional arguments to CodeChecker log command. For supported arguments, run `CodeChecker log --help`. The command `CodeChecker: Preview CodeChecker log in terminal` command shows the resulting command line.",
           "default": "",
-          "order": 7
+          "order": 8
         },
         "codechecker.editor.showDatabaseDialog": {
           "type": "boolean",

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -197,6 +197,8 @@ export class ExecutorBridge implements Disposable {
             : executorConfig.has('threadCount') ? executorConfig.get<string>('threadCount') : undefined;
         // FIXME: Add support for selecting a specific workspace folder
 
+        const ccTimeout = workspace.getConfiguration('codechecker.executor').get<number>('analysisTimeout') ?? 0;
+
         const args = [
             'analyze',
             '--output', reportsFolder
@@ -204,6 +206,10 @@ export class ExecutorBridge implements Disposable {
 
         if (ccThreads) {
             args.push('-j', ccThreads);
+        }
+
+        if (ccTimeout > 0) {
+            args.push('--timeout', ccTimeout.toString());
         }
 
         if (this.checkedVersion < [6, 22, 0]) {


### PR DESCRIPTION
Fixes #150.

I chose the default timeout to be 60s - there's no good default, but in general this timeout should be a last resort to save system resources, in case of an accidentally enabled long-running checker.