### PR TITLE
Do not analyze unsupported files on save

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "code analysis"
   ],
   "activationEvents": [
-    "onCommand:codechecker.backend.reloadMetadata",
-    "onView:codechecker.views.overview",
-    "onFileSystem:file"
+    "onStartupFinished"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -25,6 +25,8 @@ import { NotificationType } from '../../editor/notifications';
 import { Editor } from '../../editor';
 import { SidebarContainer } from '../../sidebar';
 import { ReportTreeItem } from '../../sidebar/views';
+import { isSupportedFile } from '../../utils/files';
+import { state } from '../../utils/state';
 
 // Structure:
 //   CodeChecker analyzer version: \n {"base_package_version": "M.m.p", ...}
@@ -116,8 +118,10 @@ export class ExecutorBridge implements Disposable {
             ExtensionApi.executorManager
         ));
 
-        this.updateCompilationDatabasePaths();
-        this.checkVersion();
+        if (state.workspaceSupported) {
+            this.updateCompilationDatabasePaths();
+            this.checkVersion();
+        }
     }
 
     dispose() {
@@ -387,13 +391,13 @@ export class ExecutorBridge implements Disposable {
     public async analyzeCurrentFile() {
         const currentFile = window.activeTextEditor?.document.uri;
 
-        if (currentFile !== undefined && this.isSupportedFile(currentFile)) {
+        if (currentFile !== undefined && isSupportedFile(currentFile)) {
             await this.analyzeFile(currentFile);
         }
     }
 
     public async analyzeFile(file: Uri) {
-        if (!await this.checkVersion()) {
+        if (!state.workspaceSupported || !await this.checkVersion()) {
             return;
         }
 
@@ -411,7 +415,7 @@ export class ExecutorBridge implements Disposable {
     }
 
     public async analyzeProject() {
-        if (!await this.checkVersion()) {
+        if (!state.workspaceSupported || !await this.checkVersion()) {
             return;
         }
 
@@ -431,9 +435,10 @@ export class ExecutorBridge implements Disposable {
     }
 
     public async getFileAnalysisStatus() {
-        if (!await this.checkVersion()) {
+        if (!state.workspaceSupported || !await this.checkVersion()) {
             return;
         }
+
         if (this.checkedVersion < [ 6, 27, 0 ]) {
             const statusNode = SidebarContainer.reportsView.getNodeById('statusItem');
             statusNode?.setLabelAndIcon('Status report requires CodeChecker 6.27.0 or higher.');
@@ -579,7 +584,7 @@ export class ExecutorBridge implements Disposable {
     }
 
     public async runLog(buildCommand?: string) {
-        if (!await this.checkVersion()) {
+        if (!state.workspaceSupported || !await this.checkVersion()) {
             return;
         }
 
@@ -599,7 +604,7 @@ export class ExecutorBridge implements Disposable {
     }
 
     public async reloadCheckerData() {
-        if (!await this.checkVersion()) {
+        if (!state.workspaceSupported || !await this.checkVersion()) {
             return;
         }
 
@@ -642,7 +647,7 @@ export class ExecutorBridge implements Disposable {
     }
 
     public async parseMetadata(...files: Uri[]) {
-        if (!await this.checkVersion()) {
+        if (!state.workspaceSupported || !await this.checkVersion()) {
             return;
         }
 
@@ -927,20 +932,5 @@ export class ExecutorBridge implements Disposable {
         }
 
         this._databaseLocationChanged.fire();
-    }
-
-    private isSupportedFile(uri: Uri | undefined): boolean {
-        if (uri === undefined) {
-            return false;
-        }
-
-        const extensions = [
-            '.c',
-            '.cc',
-            '.cpp',
-            '.cxx'
-        ];
-
-        return extensions.find(ext => uri.path.endsWith(ext)) !== undefined;
     }
 }

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -25,7 +25,11 @@ import { NotificationType } from '../../editor/notifications';
 import { Editor } from '../../editor';
 import { SidebarContainer } from '../../sidebar';
 import { ReportTreeItem } from '../../sidebar/views';
-import { isSupportedFile } from '../../utils/files';
+import {
+    COMPILE_COMMANDS_JSON,
+    getCompilationDatabasePath,
+    getOutputFolder,
+    isSupportedFile } from '../../utils/files';
 import { state } from '../../utils/state';
 
 // Structure:
@@ -255,12 +259,12 @@ export class ExecutorBridge implements Disposable {
                 // FIXME: Add a way to analyze all open workspaces, or a selected one
                 this._bridgeMessages.fire('>>> Using CodeChecker\'s built-in compilation database resolver\n');
                 let analysisPath;
-                const ccDbFolder = getConfigAndReplaceVariables('codechecker.backend', 'compilationDatabasePath');
-                const outputFolder = getConfigAndReplaceVariables('codechecker.backend', 'outputFolder');
+                const ccDbFolder = getCompilationDatabasePath();
+                const outputFolder = getOutputFolder();
                 if (ccDbFolder !== undefined) {
-                    analysisPath = path.join(ccDbFolder, 'compile_commands.json');
+                    analysisPath = path.join(ccDbFolder, COMPILE_COMMANDS_JSON);
                 } else if (outputFolder !== undefined) {
-                    analysisPath = path.join(outputFolder, 'compile_commands.json');
+                    analysisPath = path.join(outputFolder, COMPILE_COMMANDS_JSON);
                 } else {
                     const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
                     analysisPath = path.join(workspaceFolder, '.codechecker');
@@ -450,6 +454,11 @@ export class ExecutorBridge implements Disposable {
             return;
         }
 
+        const fileUri = window.activeTextEditor?.document.uri;
+        if (!isSupportedFile(fileUri)) {
+            return;
+        }
+
         if (this.checkedVersion < [ 6, 27, 0 ]) {
             const statusNode = SidebarContainer.reportsView.getNodeById('statusItem');
             statusNode?.setLabelAndIcon('Status report requires CodeChecker 6.27.0 or higher.');
@@ -458,7 +467,6 @@ export class ExecutorBridge implements Disposable {
 
         const ccPath = getConfigAndReplaceVariables('codechecker.executor', 'executablePath') || 'CodeChecker';
         const reportsFolder = this.getReportsFolder();
-        const fileUri = window.activeTextEditor?.document.uri;
         const fsPath = fileUri?.fsPath;
 
         const statusArgs = [
@@ -532,6 +540,7 @@ export class ExecutorBridge implements Disposable {
                             analyzerStatuses.push(existingStatusNode);
                         } else {
                             existingStatusNode.iconPath = new ThemeIcon(iconname);
+                            analyzerStatuses.push(existingStatusNode);
                         }
                     }
                 }
@@ -544,6 +553,9 @@ export class ExecutorBridge implements Disposable {
                         new ThemeIcon('question', new ThemeColor('charts.red')));
                 } else if (failed > 0) {
                     statusNode?.setLabelAndIcon('Analysis failed',
+                        new ThemeIcon('error', new ThemeColor('charts.red')));
+                } else if (missing > 0 && outdated === 0 && uptodate === 0) {
+                    statusNode?.setLabelAndIcon('Analysis is missing',
                         new ThemeIcon('error', new ThemeColor('charts.red')));
                 } else if (outdated === 0 && failed === 0) {
                     statusNode?.setLabelAndIcon('Analysis is up-to-date',
@@ -658,7 +670,12 @@ export class ExecutorBridge implements Disposable {
     }
 
     public async parseMetadata(...files: Uri[]) {
-        if (!state.workspaceSupported || !await this.checkVersion()) {
+        if (!state.workspaceSupported || files.length === 0 || !await this.checkVersion()) {
+            return;
+        }
+
+        if (!files.find(uri => isSupportedFile(uri))) {
+            ExtensionApi.diagnostics.fireDiagnosticsUpdate();
             return;
         }
 

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -387,7 +387,7 @@ export class ExecutorBridge implements Disposable {
     public async analyzeCurrentFile() {
         const currentFile = window.activeTextEditor?.document.uri;
 
-        if (currentFile !== undefined) {
+        if (currentFile !== undefined && this.isSupportedFile(currentFile)) {
             await this.analyzeFile(currentFile);
         }
     }
@@ -927,5 +927,20 @@ export class ExecutorBridge implements Disposable {
         }
 
         this._databaseLocationChanged.fire();
+    }
+
+    private isSupportedFile(uri: Uri | undefined): boolean {
+        if (uri === undefined) {
+            return false;
+        }
+
+        const extensions = [
+            '.c',
+            '.cc',
+            '.cpp',
+            '.cxx'
+        ];
+
+        return extensions.find(ext => uri.path.endsWith(ext)) !== undefined;
     }
 }

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -254,7 +254,15 @@ export class ExecutorBridge implements Disposable {
             } else if (files.length === 0) {
                 // FIXME: Add a way to analyze all open workspaces, or a selected one
                 this._bridgeMessages.fire('>>> Using CodeChecker\'s built-in compilation database resolver\n');
-                args.push(workspace.workspaceFolders[0].uri.fsPath);
+                let analysisPath;
+                const ccFolder = getConfigAndReplaceVariables('codechecker.backend', 'outputFolder');
+                if (ccFolder !== undefined) {
+                    analysisPath = path.join(ccFolder, 'compile_commands.json');
+                } else {
+                    const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
+                    analysisPath = path.join(workspaceFolder, '.codechecker');
+                }
+                args.push(analysisPath);
             } else if (files.length === 1) {
                 this._bridgeMessages.fire('>>> Using CodeChecker\'s built-in compilation database resolver\n');
                 args.push(files[0].fsPath);

--- a/src/backend/executor/bridge.ts
+++ b/src/backend/executor/bridge.ts
@@ -255,9 +255,12 @@ export class ExecutorBridge implements Disposable {
                 // FIXME: Add a way to analyze all open workspaces, or a selected one
                 this._bridgeMessages.fire('>>> Using CodeChecker\'s built-in compilation database resolver\n');
                 let analysisPath;
-                const ccFolder = getConfigAndReplaceVariables('codechecker.backend', 'outputFolder');
-                if (ccFolder !== undefined) {
-                    analysisPath = path.join(ccFolder, 'compile_commands.json');
+                const ccDbFolder = getConfigAndReplaceVariables('codechecker.backend', 'compilationDatabasePath');
+                const outputFolder = getConfigAndReplaceVariables('codechecker.backend', 'outputFolder');
+                if (ccDbFolder !== undefined) {
+                    analysisPath = path.join(ccDbFolder, 'compile_commands.json');
+                } else if (outputFolder !== undefined) {
+                    analysisPath = path.join(outputFolder, 'compile_commands.json');
                 } else {
                     const workspaceFolder = workspace.workspaceFolders[0].uri.fsPath;
                     analysisPath = path.join(workspaceFolder, '.codechecker');

--- a/src/backend/processor/diagnostics.ts
+++ b/src/backend/processor/diagnostics.ts
@@ -41,6 +41,10 @@ export class DiagnosticsApi {
         return undefined;
     }
 
+    public fireDiagnosticsUpdate() {
+        this._diagnosticsUpdated.fire();
+    }
+
     public setSelectedEntry(position?: {file: string, idx: number}) {
         if (position) {
             const activeFile = this.getFileDiagnostics(Uri.file(position.file)) ?? [];
@@ -88,7 +92,8 @@ export class DiagnosticsApi {
             return;
         }
 
-        ExtensionApi.executorBridge.parseMetadata(...filesToLoad.map(file => Uri.file(file)))
+        ExtensionApi.executorBridge.parseMetadata(...filesToLoad
+            .map(file => Uri.file(file)))
             .catch((err: any) => console.log(`Internal error in reloadDiagnostics: ${err}`));
     }
 

--- a/src/editor/diagnostics.ts
+++ b/src/editor/diagnostics.ts
@@ -157,7 +157,7 @@ export class DiagnosticRenderer {
         if (this.customSeverities && this.customSeverities[severity]) {
             const severityString = this.customSeverities[severity];
 
-            if (typeof severityString === 'string' && this._severityMap[severityString.toLowerCase()]) {
+            if (typeof severityString === 'string' && this._severityMap[severityString.toLowerCase()] !== undefined) {
                 return this._severityMap[severityString.toLowerCase()];
             } else {
                 Editor.loggerPanel.window.appendLine(

--- a/src/editor/initialize.ts
+++ b/src/editor/initialize.ts
@@ -2,6 +2,7 @@ import { ExtensionContext, Uri, commands, window, workspace } from 'vscode';
 import { ExtensionApi } from '../backend';
 import { Editor } from './editor';
 import { NotificationType } from './notifications';
+import { state } from '../utils/state';
 
 export class FolderInitializer {
     constructor(_ctx: ExtensionContext) {
@@ -27,7 +28,7 @@ export class FolderInitializer {
     async showDialog() {
         const workspaceFolder = workspace.workspaceFolders?.length && workspace.workspaceFolders[0].uri;
 
-        if (!workspaceFolder) {
+        if (!workspaceFolder || !state.workspaceSupported) {
             return;
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ExtensionApi } from './backend';
 import { Editor } from './editor';
 import { SidebarContainer } from './sidebar';
+import { checkWorkspace } from './utils/files';
 
 export interface CodeCheckerExtension {
     extensionApi: typeof ExtensionApi,
@@ -14,6 +15,8 @@ export function activate(context: vscode.ExtensionContext): CodeCheckerExtension
     ExtensionApi.init(context);
     Editor.init(context);
     SidebarContainer.init(context);
+
+    checkWorkspace();
 
     console.log('Extension "codechecker" activated');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,13 +10,14 @@ export interface CodeCheckerExtension {
     editor: typeof Editor
 }
 
-export function activate(context: vscode.ExtensionContext): CodeCheckerExtension {
+export async function activate(context: vscode.ExtensionContext): Promise<CodeCheckerExtension> {
     // Backend must be initialized before the frontend
-    ExtensionApi.init(context);
-    Editor.init(context);
-    SidebarContainer.init(context);
 
-    checkWorkspace();
+    if (await checkWorkspace()) {
+        ExtensionApi.init(context);
+        Editor.init(context);
+        SidebarContainer.init(context);
+    }
 
     console.log('Extension "codechecker" activated');
 

--- a/src/sidebar/views/reports.ts
+++ b/src/sidebar/views/reports.ts
@@ -19,6 +19,7 @@ import {
 import { ExtensionApi } from '../../backend';
 import { DiagnosticReport } from '../../backend/types';
 import { SidebarContainer } from '../sidebar_container';
+import { isSupportedFile } from '../../utils/files';
 
 export class ReportTreeItem extends TreeItem {
     parent: ReportTreeItem | undefined;
@@ -378,11 +379,23 @@ export class ReportsView implements TreeDataProvider<ReportTreeItem> {
 
     // Get root level items.
     getRootItems(): ReportTreeItem[] | undefined {
-        if (!this.currentEntryList?.length) {
+        if (!isSupportedFile(this.currentFile)) {
             const statusNode = SidebarContainer.reportsView.getNodeById('statusItem');
-            statusNode?.setLabelAndIcon('Not in compilation database',
-                new ThemeIcon('question', new ThemeColor('charts.orange')));
+            if (statusNode !== undefined) {
+                statusNode.setLabelAndIcon('Not supported by codechecker',
+                    new ThemeIcon('question', new ThemeColor('charts.orange')));
+                // statusNode.children = [];
+                statusNode.collapsibleState = TreeItemCollapsibleState.None;
+                const rootNode = statusNode.parent;
+                if (rootNode !== undefined) {
+                    rootNode.children = [ statusNode ];
+                }
+            }
             return statusNode ? [ statusNode ] : undefined;
+        }
+
+        if (this.currentEntryList === undefined) {
+            return undefined;
         }
 
         const severityItems: { [key: string]: TreeDiagnosticReport[] } = {};

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,0 +1,42 @@
+import { Uri, workspace } from 'vscode';
+import { state } from './state';
+
+const EXTENSIONS = [
+    '.c',
+    '.cc',
+    '.cpp',
+    '.cxx'
+];
+
+export function isSupportedFile(uri: Uri | undefined): boolean {
+    if (uri === undefined) {
+        return false;
+    }
+
+    return EXTENSIONS.find(ext => uri.path.endsWith(ext)) !== undefined;
+}
+
+export async function isSupportedWorkspace() {
+    const supported = await workspace.findFiles(
+        `**/*.{${EXTENSIONS.join(',')}}`,
+        '**/{node_modules,.git}/**',
+        1
+    );
+
+    return supported.length > 1;
+}
+
+export async function checkWorkspace() {
+    if (workspace.name === undefined) {
+        state.workspaceSupported = false;
+        console.log('No open workspace.');
+        return;
+    }
+    const supported = await isSupportedWorkspace();
+    if (supported) {
+        state.workspaceSupported = true;
+    } else {
+        state.workspaceSupported = false;
+        console.log(`workspace ${workspace.name} does not contain supported files.`);
+    }
+}

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,5 +1,6 @@
 import { Uri, workspace } from 'vscode';
 import { state } from './state';
+import { getConfigAndReplaceVariables } from './config';
 
 const EXTENSIONS = [
     '.c',
@@ -7,6 +8,8 @@ const EXTENSIONS = [
     '.cpp',
     '.cxx'
 ];
+
+export const COMPILE_COMMANDS_JSON = 'compile_commands.json';
 
 export function isSupportedFile(uri: Uri | undefined): boolean {
     if (uri === undefined) {
@@ -30,7 +33,7 @@ export async function checkWorkspace() {
     if (workspace.name === undefined) {
         state.workspaceSupported = false;
         console.log('No open workspace.');
-        return;
+        return false;
     }
     const supported = await isSupportedWorkspace();
     if (supported) {
@@ -39,4 +42,13 @@ export async function checkWorkspace() {
         state.workspaceSupported = false;
         console.log(`workspace ${workspace.name} does not contain supported files.`);
     }
+    return state.workspaceSupported;
+}
+
+export function getOutputFolder() {
+    return getConfigAndReplaceVariables('codechecker.backend', 'outputFolder');
+}
+
+export function getCompilationDatabasePath() {
+    return getConfigAndReplaceVariables('codechecker.backend', 'compilationDatabasePath');
 }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -18,12 +18,12 @@ export function isSupportedFile(uri: Uri | undefined): boolean {
 
 export async function isSupportedWorkspace() {
     const supported = await workspace.findFiles(
-        `**/*.{${EXTENSIONS.join(',')}}`,
+        `**/*{${EXTENSIONS.join(',')}}`,
         '**/{node_modules,.git}/**',
         1
     );
 
-    return supported.length > 1;
+    return supported.length > 0;
 }
 
 export async function checkWorkspace() {

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -1,0 +1,5 @@
+export class ExtensionState {
+    public workspaceSupported = false;
+}
+
+export const state = new ExtensionState();


### PR DESCRIPTION
This PR prevents analyzing the currently edited file on save if the file is unsupported by codechecker.

Related to #164 
