### PR TITLE
Version bump for yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,11 @@
+approvedGitRepositories:
+  - "**"
+
+enableScripts: true
+
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 0
 
 plugins:
   - path: yarn_plugins/plugin-list.js

--- a/package.json
+++ b/package.json
@@ -416,5 +416,5 @@
     "shell-quote": "^1.8.1",
     "tslib": "^2.6.2"
   },
-  "packageManager": "yarn@4.1.0"
+  "packageManager": "yarn@4.17.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@aashutoshrathi/word-wrap@npm:^1.2.3":


### PR DESCRIPTION
This PR bumps yarn version to 4.17.0 to fix CI pipelines.